### PR TITLE
Add install instructions for Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
     # # # See the included license for more details.
 
 
+## NRLMMD-GEOIPS/recenter_tc#3: 2022-12-07, add mac install instructions
+### Documentation
+* **New mac-specific system requirements**
+    * xcode command line tools
+    * Updated `llvm`, `clang`, and `libomp`
+* **Additional environment variables for install on mac**
+    * LIBRARY_PATH
+    * PATH
+
+
 # v1.5.1: 2022-07-13, update test repo outputs
 
 ### Major New Functionality

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Installation Guide
 ==================
 
 This installation guide has installation steps specific to installing this plugin, including
-the base geoips conda install if not already installed.
+the base geoips conda install if not already installed. Note that there are additional requirements 
+and slightly different installation steps for Linux and Mac.
 
 
 System Requirements
@@ -29,6 +30,13 @@ System Requirements
 * Fortran compiler supported by f2py required for akima86 dependency - load appropriately prior to installation.
 * git > 2.19.1 for "git -C" clone commands
 * Test data repos contained in $GEOIPS_BASEDIR/test_data/ for tests to pass.
+
+Additional Mac-specific System Requirements
+-------------------------------------------
+* xcode command line tools
+  Can be installed using `xcode-select --install`
+* Updated `llvm`, `clang`, and `libomp`
+  Can be installed via Homebrew using `brew install llvm libomp`
 
 
 Setup System Environment Variables
@@ -93,7 +101,7 @@ IF REQUIRED: Install and test base geoips conda environment
     $GEOIPS_BASEDIR/geoips_packages/geoips/base_install_and_test.sh dev
 ```
 
-Install recenter_tc package
+Install recenter_tc package on Linux
 -------------------------
 ```bash
     $GEOIPS_BASEDIR/geoips_packages/recenter_tc/setup.sh repo_clone
@@ -101,6 +109,18 @@ Install recenter_tc package
     source $GEOIPS_CONFIG_FILE
     pip install -e $GEOIPS_BASEDIR/geoips_packages/geoips
     $GEOIPS_BASEDIR/geoips_packages/recenter_tc/setup.sh install
+```
+
+Install recenter_tc package on Mac
+-------------------------
+```bash
+    $GEOIPS_BASEDIR/geoips_packages/recenter_tc/setup.sh repo_clone
+    $GEOIPS_BASEDIR/geoips_packages/recenter_tc/setup.sh repo_update
+    source $GEOIPS_CONFIG_FILE
+    pip install -e $GEOIPS_BASEDIR/geoips_packages/geoips
+    LIBRARY_PATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib \
+        PATH=/usr/local/opt/llvm/bin:$PATH \
+        $GEOIPS_BASEDIR/geoips_packages/recenter_tc/setup.sh install
 ```
 
 Test recenter_tc installation - these test scripts provide you with the full command line calls


### PR DESCRIPTION
# Related Issues
fixes NRLMMD-GEOIPS/geoips#[XXX]

# Testing Instructions
I've tested this on Mac and it works. If someone else has a Mac, it would be worth testing the instructions, then running `./tests/scripts/amsr2.tc.color37.imagery_clean.sh` to ensure a zero exit status.

# Summary
## NRLMMD-GEOIPS/recenter_tc#3: 2022-12-07, add mac install instructions
### Documentation
* **New mac-specific system requirements**
    * xcode command line tools
    * Updated `llvm`, `clang`, and `libomp`
* **Additional environment variables for install on mac**
    * LIBRARY_PATH
    * PATH 