### PR TITLE
v1.10.0a0: clat_clon_resolution_shape -> center_coordinates

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -16,6 +16,14 @@
 Release Notes
 *************
 
+Version 1.10
+------------
+
+.. toctree::
+   :maxdepth: 1
+
+   v1_10_0a0
+
 Version 1.9
 -----------
 

--- a/docs/source/releases/v1_10_0a0.rst
+++ b/docs/source/releases/v1_10_0a0.rst
@@ -21,7 +21,7 @@ Breaking Changes
 Update clat_clon_resolution_shape plugin name to center_coordinates
 -------------------------------------------------------------------
 
-*From GEOIPS/geoips#195: 2023-03-30, update sector_spec/metadata_generator*
+*From GEOIPS/geoips#195: 2023-04-28, update sector_spec/metadata_generator*
 
 When updating area_def_generators interface to sector_spec_generators, and
 trackfile_parsers interface to sector_metadata_generators, also generalized

--- a/docs/source/releases/v1_10_0a0.rst
+++ b/docs/source/releases/v1_10_0a0.rst
@@ -1,0 +1,34 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.10.0a0 (2023-04-28)
+*****************************
+
+* Update clat_clon_resolution_shape to center_coordinates
+
+Breaking Changes
+================
+
+Remove references to GEOIPS BASEDIR
+-----------------------------------
+
+*From GEOIPS/geoips#195: 2023-03-30, update sector_spec/metadata_generator*
+
+When updating area_def_generators interface to sector_spec_generators, and
+trackfile_parsers interface to sector_metadata_generators, also generalized
+plugin naming.
+
+clat_clon_resolution_shape now referred to as "center_coordinates"
+
+::
+
+  modified:   recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py

--- a/docs/source/releases/v1_10_0a0.rst
+++ b/docs/source/releases/v1_10_0a0.rst
@@ -18,8 +18,8 @@ Version 1.10.0a0 (2023-04-28)
 Breaking Changes
 ================
 
-Remove references to GEOIPS BASEDIR
------------------------------------
+Update clat_clon_resolution_shape plugin name to center_coordinates
+-------------------------------------------------------------------
 
 *From GEOIPS/geoips#195: 2023-03-30, update sector_spec/metadata_generator*
 

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -298,11 +298,9 @@ def recenter_tc(xobjs, area_def, variables, recenter_variables=None):
 
 def recenter_area_def(area_def, fields):
     from geoips.sector_utils.tc_tracks import get_tc_long_description
-    from geoips.plugins.modules.sector_loaders.dynamic.clat_clon_resolution_shape import (
-        clat_clon_resolution_shape,
-    )
+    from geoips.plugins.modules.sector_spec_generators import center_coordinates
 
-    new_area_def = clat_clon_resolution_shape(
+    new_area_def = center_coordinates.call(
         area_id=area_def.area_id,
         long_description=get_tc_long_description(area_def.area_id, fields),
         clat=fields["clat"],


### PR DESCRIPTION
# Reviewer Checklist
https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
fixes NRLMMD-GEOIPS/geoips#195

Requires this geoips PR to work:
https://github.com/NRLMMD-GEOIPS/geoips/pull/196

# Testing Instructions
$GEOIPS/tests/test_full_install.sh

# Summary
Version 1.10.0a1 (2023-04-28)
*****************************

* Update clat_clon_resolution_shape to center_coordinates

Breaking Changes
================

Remove references to GEOIPS BASEDIR
-----------------------------------

*From GEOIPS/geoips#195: 2023-03-30, update sector_spec/metadata_generator*

When updating area_def_generators interface to sector_spec_generators, and
trackfile_parsers interface to sector_metadata_generators, also generalized
plugin naming.

clat_clon_resolution_shape now referred to as "center_coordinates"

::

  modified:   recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py

# Output
<!---
* Optional output demonstrating functionality - command line or imagery output
* If there is any additional command line output you can copy/paste here to indicate the changes you made work as expected, please include
* Imagery output is EXPECTED for new or changed image products
    * Ideally include the least amount of formatting possible in test outputs
    * Clean imagery, no YAML metadata outputs, small representative sector
    * We want to minimize the dependencies that could cause test outputs to change
* Related Testing is EXPECTED for new image products
    * Create <repo>/tests/scripts/<testname>.sh
    * Update <repo>/tests/test_all.sh
--->
