### PR TITLE
v1.10.3 recenter_tc - VERSION RELEASE main - final naming changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,135 @@
-*.pyc
-*.eggs/
-*.egg-info
 archer_test*
+
+_version.py
 *diff_test_output*
-version.py
+.vscode
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/

--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,8 @@ Version 1.10
 .. toctree::
    :maxdepth: 1
 
+   v1_10_3
+   v1_10_2
    v1_10_0
    v1_10_0a2
    v1_10_0a1

--- a/docs/source/releases/v1_10_3.rst
+++ b/docs/source/releases/v1_10_3.rst
@@ -16,6 +16,7 @@ Version 1.10.3 (2023-07-24)
 * Update original_source_filenames -> source_file_names in YAML metadata outputs
 * Bug Fix: Re-implement increased lon padding for AMSU-B
 * Bug Fix: Add try/except statement for AttributeError around recenter_tc_area_def call
+* Bug Fix: Update pyproject.toml/.gitignore to standard formatting.
 
 Breaking Changes
 ================
@@ -47,6 +48,17 @@ Update original_source_filenames -> source_file_names in YAML metadata outputs
 
 Bug Fixes
 =========
+
+Update pyproject.toml/.gitignore to standard formatting
+-------------------------------------------------------
+
+Finalize pyproject.toml and .gitignore formatting - include package-data,
+plugin-packages, and use _version.py vs version.py.
+
+::
+
+    pyproject.toml
+    .gitignore
 
 Re-implement increased lon padding for AMSU-B
 ---------------------------------------------

--- a/docs/source/releases/v1_10_3.rst
+++ b/docs/source/releases/v1_10_3.rst
@@ -1,0 +1,72 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.10.3 (2023-07-24)
+***************************
+
+* Update original_source_filenames -> source_file_names in YAML metadata outputs
+* Bug Fix: Re-implement increased lon padding for AMSU-B
+* Bug Fix: Add try/except statement for AttributeError around recenter_tc_area_def call
+
+Breaking Changes
+================
+
+Update original_source_filenames -> source_file_names in YAML metadata outputs
+------------------------------------------------------------------------------
+
+*From issue GEOIPS#266: 2023-07-05, update reader attribute names*
+
+::
+
+  modified:   tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml
+  modified:   tests/outputs/amsr2.tc.windspeed.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_windspeed_142kts_85p08_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima-clean.png.yaml
+  modified:   tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/nrcs_image/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima.png.yaml
+  modified:   tests/outputs/ascat_uhr.tc.windbarbs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_windbarbs_120kts_100p00_res0p1-akima-clean.png.yaml
+  modified:   tests/outputs/gmi.tc.89pct.imagery_clean/20200917_172047_AL202020_gmi_GPM_89pct_113kts_17p67_res1p0-arH89-clean.png.yaml
+  modified:   tests/outputs/hy2b.tc.windspeed.imagery_clean/20211202_084043_WP272021_hscat_hy-2b_windspeed_100kts_98p29_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/imerg.tc.Rain.imagery_clean/20200917_170000_AL202020_imerg_GPM_Rain_113kts_36p43_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/metopc_knmi_125.tc.windbarbs.imagery_clean/20210421_014245_WP022021_ascat_metop-c_windbarbs_120kts_77p14_res0p5-akima-clean.png.yaml
+  modified:   tests/outputs/modis.tc.Infrared.imagery_clean/20210104_201500_SH082021_modis_aqua_Infrared_55kts_100p00_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/oscat.tc.windspeed.imagery_clean/20210209_025351_SH192021_oscat_scatsat-1_windspeed_133kts_73p31_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/smap.tc.windspeed.imagery_clean/20210926_085600_WP202021_smap-spd_smap_windspeed_139kts_54p35_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/smap.tc.windspeed.imagery_clean/20210926_210400_WP202021_smap-spd_smap_windspeed_104kts_74p70_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/smos.tc.windspeed.imagery_clean/20200216_124335_SH162020_smos-spd_smos_windspeed_75kts_38p89_res1p0-akima-clean.png.yaml
+  modified:   tests/outputs/ssmi.tc.37pct.imagery_clean/20200519_080900_IO012020_ssmi_F15_37pct_105kts_48p73_res1p0-arH37-clean.png.yaml
+  modified:   tests/outputs/ssmis.tc.color91.imagery_clean/20200519_095800_IO012020_ssmis_F16_color91_103kts_98p36_res1p0-arH91-clean.png.yaml
+  modified:   tests/outputs/viirs.tc.Infrared-Gray.imagery_clean/20210209_074210_SH192021_viirs_noaa-20_Infrared-Gray_127kts_100p00_res1p0-akima-clean.png.yaml
+
+Bug Fixes
+=========
+
+Re-implement increased lon padding for AMSU-B
+---------------------------------------------
+
+Re-implement increased lon padding for AMSU-B
+
+* This was accidentally reverted to 15 in a previous pull request
+
+::
+
+    modified: recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+    
+Add try/except statement for AttributeError around recenter_tc_area_def call
+----------------------------------------------------------------------------
+
+Add handling for potential AttributeError raised during recenter_tc_area_def call
+
+* If spatial sectoring fails returns nothing under recenter_with_archer, an attribute error
+  is raised as an ".attr" method would be called on a "None" type object
+  
+::
+
+    modified: recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,27 @@ find = {namespaces = false}
 [tool.setuptools.package-dir]
 "" = "."
 
+[tool.setuptools.package-data]
+"*" = [
+    "plugins/*.yaml",
+    "plugins/*/*.yaml",
+    "plugins/*/*/*.yaml",
+    "plugins/*/*/*/*.yaml",
+    "plugins/*/*/*/*/*.yaml",
+    "plugins/*.txt",
+    "plugins/*/*.txt",
+    "plugins/*/*/*.txt",
+    "plugins/*/*/*/*.txt",
+    "plugins/*/*/*/*/*.txt",
+]
+
 [tool.setuptools.dynamic]
 entry-points = {file = ["entry-points.ini"]}
 
 [tool.setuptools_scm]
 "version_scheme" = "post-release"  # Use current version .postN vs incrementing
 "local_scheme" = "no-local-version"  # Don't include hash, or date, just postN
-"write_to" = "recenter_tc/version.py"  # Write an actual file
+"write_to" = "recenter_tc/_version.py"  # Write an actual file
 
 [project]
 name = "recenter_tc"
@@ -33,6 +47,9 @@ dependencies = [
     "archer @ git+https://github.com/ajwimmers/archer.git",
     "akima86 @ git+https://github.com/NRLMMD-GEOIPS/akima86.git"
 ]
+
+[project.entry-points."geoips.plugin_packages"]
+"recenter_tc" = "recenter_tc"
 
 [project.entry-points."geoips.sector_adjusters"]
 "recenter_tc" = "recenter_tc.plugins.modules.sector_adjusters.recenter_tc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,6 @@ dependencies = [
     "akima86 @ git+https://github.com/NRLMMD-GEOIPS/akima86.git"
 ]
 
-[project.entry-points."geoips.plugin_packages"]
-"recenter_tc" = "recenter_tc"
-
 [project.entry-points."geoips.sector_adjusters"]
 "recenter_tc" = "recenter_tc.plugins.modules.sector_adjusters.recenter_tc"
 
@@ -46,3 +43,4 @@ dependencies = [
 
 [project.entry-points."geoips.output_comparisons"]
 "compare_outputs_recenter_tc" = "recenter_tc.compare_outputs_recenter_tc:compare_outputs_recenter_tc"
+

--- a/recenter_tc/__init__.py
+++ b/recenter_tc/__init__.py
@@ -10,4 +10,4 @@
 # # # for more details. If you did not receive the license, for more information see:
 # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-from .version import __version__, __version_tuple__
+from ._version import __version__, __version_tuple__

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -295,13 +295,18 @@ def call(
             set(recenter_variables).intersection(set(xobj.variables.keys()))
         )
         if include_vars and curr_recenter_variables:
-            curr_recentered_area_defs, curr_out_fnames = recenter_tc_area_def(
-                area_def,
-                xobj,
-                variables=curr_recenter_variables,
-                akima_only=akima_only,
-                include_archer_info=include_archer_info,
-            )
+            try:
+                curr_recentered_area_defs, curr_out_fnames = recenter_tc_area_def(
+                    area_def,
+                    xobj,
+                    variables=curr_recenter_variables,
+                    akima_only=akima_only,
+                    include_archer_info=include_archer_info,
+                )
+            except AttributeError:
+                # If the archer spatial sectoring does not yield any data,
+                # it will result in an attribute error
+                continue
             out_fnames += curr_out_fnames
             for varname in curr_recentered_area_defs:
                 recentered_area_defs[varname] = curr_recentered_area_defs[varname]
@@ -398,7 +403,7 @@ def recenter_with_archer(
     # Need full swath width for AMSU-B and MHS for ARCHER. Need a better solution for this.
     if sect_xarray.source_name in ["amsu-b", "mhs"]:
         lat_pad = 15
-        lon_pad = 15
+        lon_pad = 25
     archer_xarray = sector_xarray_spatial(
         sect_xarray,
         [minlon, minlat, maxlon, maxlat],

--- a/tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml
+++ b/tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml
@@ -21,13 +21,13 @@ deck_line: IO, 01, 2020051806,   , BEST,   0, 134N,  862E, 140,  911, ST,  34, N
 final_storm_name: AMPHAN
 interpolated_time: 2020-05-18 07:38:42.500000
 invest_number: 91
-original_source_filenames:
-- AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc
 parser_name: bdeck_parser
 pressure: 908.28
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2020/IO/IO012020/png_clean/color37/gcom-w1/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png
 recenter_type: tb36h
 sector_type: tc
+source_file_names:
+- AMSR2-MBT_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 storm_basin: IO

--- a/tests/outputs/amsr2.tc.windspeed.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_windspeed_142kts_85p08_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/amsr2.tc.windspeed.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_windspeed_142kts_85p08_res1p0-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: IO, 01, 2020051806,   , BEST,   0, 134N,  862E, 140,  911, ST,  34, N
 final_storm_name: AMPHAN
 interpolated_time: 2020-05-18 07:38:42.500000
 invest_number: 91
-original_source_filenames:
-- AMSR2-OCEAN_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc
 parser_name: bdeck_parser
 pressure: 908.28
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2020/IO/IO012020/png_clean/windspeed/gcom-w1/20200518_073604_IO012020_amsr2_gcom-w1_windspeed_142kts_85p08_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- AMSR2-OCEAN_v2r2_GW1_s202005180620480_e202005180759470_c202005180937100.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 storm_basin: IO

--- a/tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima-clean.png.yaml
+++ b/tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: WP, 02, 2021042100,   , BEST,   0, 175N, 1252E, 120,  935, TY,  34, N
 final_storm_name: SURIGAE
 interpolated_time: 2021-04-21 01:42:00
 invest_number: 94
-original_source_filenames:
-- 210421_0142_12730_SURIGAE_210421_0000.avewr.nc
 parser_name: bdeck_parser
 pressure: 934.8
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/WP/WP022021/png_clean/nrcs/metop-c/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- 210421_0142_12730_SURIGAE_210421_0000.avewr.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 storm_basin: WP

--- a/tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/nrcs_image/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima.png.yaml
+++ b/tests/outputs/ascat_uhr.tc.nrcs.imagery_clean/nrcs_image/20210421_014200_WP022021_ascatuhr_metop-c_nrcs_120kts_98p21_res1p0-cr300-akima.png.yaml
@@ -17,7 +17,7 @@ deck_line: WP,02,2021042100,,BEST,0,17.5,125.2,120,935,TY,34,NEQ,155,170,140,160
 final_storm_name: SURIGAE
 interpolated_time: 2021-04-21 01:42:00
 invest_number: 94
-original_source_filenames:
+source_file_names:
 - 210421_0142_12730_SURIGAE_210421_0000.avewr.nc
 parser_name: gdeck_parser
 pressure: 934.8

--- a/tests/outputs/ascat_uhr.tc.windbarbs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_windbarbs_120kts_100p00_res0p1-akima-clean.png.yaml
+++ b/tests/outputs/ascat_uhr.tc.windbarbs.imagery_clean/20210421_014200_WP022021_ascatuhr_metop-c_windbarbs_120kts_100p00_res0p1-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: WP, 02, 2021042100,   , BEST,   0, 175N, 1252E, 120,  935, TY,  34, N
 final_storm_name: SURIGAE
 interpolated_time: 2021-04-21 01:42:00
 invest_number: 94
-original_source_filenames:
-- 210421_0142_12730_SURIGAE_210421_0000.WRave3.nc
 parser_name: bdeck_parser
 pressure: 934.8
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/WP/WP022021/png_clean/windbarbs/metop-c/20210421_014200_WP022021_ascatuhr_metop-c_windbarbs_120kts_100p00_res0p1-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- 210421_0142_12730_SURIGAE_210421_0000.WRave3.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 storm_basin: WP

--- a/tests/outputs/gmi.tc.89pct.imagery_clean/20200917_172047_AL202020_gmi_GPM_89pct_113kts_17p67_res1p0-arH89-clean.png.yaml
+++ b/tests/outputs/gmi.tc.89pct.imagery_clean/20200917_172047_AL202020_gmi_GPM_89pct_113kts_17p67_res1p0-arH89-clean.png.yaml
@@ -23,7 +23,7 @@ deck_line: AL, 20, 2020091718,   , BEST,   0, 197N,  537W, 115,  948, HU,  34, N
 final_storm_name: TEDDY
 interpolated_time: 2020-09-17 17:22:51.500000
 invest_number: 95
-original_source_filenames:
+source_file_names:
 - 1B.GPM.GMI.TB2016.20200917-S171519-E172017.V05A.RT-H5
 - 1B.GPM.GMI.TB2016.20200917-S172019-E172517.V05A.RT-H5
 - 1B.GPM.GMI.TB2016.20200917-S172519-E173017.V05A.RT-H5

--- a/tests/outputs/hy2b.tc.windspeed.imagery_clean/20211202_084043_WP272021_hscat_hy-2b_windspeed_100kts_98p29_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/hy2b.tc.windspeed.imagery_clean/20211202_084043_WP272021_hscat_hy-2b_windspeed_100kts_98p29_res1p0-akima-clean.png.yaml
@@ -18,7 +18,7 @@ deck_line: WP, 27, 2021120206,   , BEST,   0, 172N, 1358E,  95,  960, TY,  34, N
 final_storm_name: NYATOH
 interpolated_time: 2021-12-02 08:42:48.500000
 invest_number: 93
-original_source_filenames:
+source_file_names:
 - hscat_20211202_080644_hy_2b__15571_o_250_2204_ovw_l2.nc
 parser_name: bdeck_parser
 pressure: 955.85

--- a/tests/outputs/imerg.tc.Rain.imagery_clean/20200917_170000_AL202020_imerg_GPM_Rain_113kts_36p43_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/imerg.tc.Rain.imagery_clean/20200917_170000_AL202020_imerg_GPM_Rain_113kts_36p43_res1p0-akima-clean.png.yaml
@@ -19,13 +19,13 @@ deck_line: AL, 20, 2020091718,   , BEST,   0, 197N,  537W, 115,  948, HU,  34, N
 final_storm_name: TEDDY
 interpolated_time: 2020-09-17 17:14:30
 invest_number: 95
-original_source_filenames:
-- 3B-HHR-L.MS.MRG.3IMERG.20200917-S170000-E172959.1020.V06B.RT-H5
 parser_name: bdeck_parser
 pressure: 949.47
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2020/AL/AL202020/png_clean/Rain/GPM/20200917_170000_AL202020_imerg_GPM_Rain_113kts_36p43_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- 3B-HHR-L.MS.MRG.3IMERG.20200917-S170000-E172959.1020.V06B.RT-H5
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bal202020.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bal202020.dat
 storm_basin: AL

--- a/tests/outputs/metopc_knmi_125.tc.windbarbs.imagery_clean/20210421_014245_WP022021_ascat_metop-c_windbarbs_120kts_77p14_res0p5-akima-clean.png.yaml
+++ b/tests/outputs/metopc_knmi_125.tc.windbarbs.imagery_clean/20210421_014245_WP022021_ascat_metop-c_windbarbs_120kts_77p14_res0p5-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: WP, 02, 2021042100,   , BEST,   0, 175N, 1252E, 120,  935, TY,  34, N
 final_storm_name: SURIGAE
 interpolated_time: 2021-04-21 01:43:52
 invest_number: 94
-original_source_filenames:
-- ascat_20210421_010000_metopc_12730_eps_o_coa_3203_ovw.l2.nc
 parser_name: bdeck_parser
 pressure: 934.79
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/WP/WP022021/png_clean/windbarbs/metop-c/20210421_014245_WP022021_ascat_metop-c_windbarbs_120kts_77p14_res0p5-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- ascat_20210421_010000_metopc_12730_eps_o_coa_3203_ovw.l2.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp022021.dat
 storm_basin: WP

--- a/tests/outputs/modis.tc.Infrared.imagery_clean/20210104_201500_SH082021_modis_aqua_Infrared_55kts_100p00_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/modis.tc.Infrared.imagery_clean/20210104_201500_SH082021_modis_aqua_Infrared_55kts_100p00_res1p0-akima-clean.png.yaml
@@ -18,7 +18,7 @@ deck_line: SH, 08, 2021010418,   , BEST,   0, 157S,  763E,  50,  993, TS,  34, N
 final_storm_name: DANILO
 interpolated_time: 2021-01-04 20:17:30
 invest_number: 96
-original_source_filenames:
+source_file_names:
 - MYD021KM.A2021004.2005.061.NRT.hdf
 - MYD03.A2021004.2005.061.NRT.hdf
 - MYD021KM.A2021004.2010.061.NRT.hdf

--- a/tests/outputs/oscat.tc.windspeed.imagery_clean/20210209_025351_SH192021_oscat_scatsat-1_windspeed_133kts_73p31_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/oscat.tc.windspeed.imagery_clean/20210209_025351_SH192021_oscat_scatsat-1_windspeed_133kts_73p31_res1p0-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: SH, 19, 2021020900,   , BEST,   0, 141S,  830E, 135,  923, ST,  34, N
 final_storm_name: FARAJI
 interpolated_time: 2021-02-09 02:55:52
 invest_number: 90
-original_source_filenames:
-- oscat_20210209_022459_scasa1_23155_o_250_2202_ovw_l2.nc
 parser_name: bdeck_parser
 pressure: 925.91
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/SH/SH192021/png_clean/windspeed/scatsat-1/20210209_025351_SH192021_oscat_scatsat-1_windspeed_133kts_73p31_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- oscat_20210209_022459_scasa1_23155_o_250_2202_ovw_l2.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bsh192021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bsh192021.dat
 storm_basin: SH

--- a/tests/outputs/smap.tc.windspeed.imagery_clean/20210926_085600_WP202021_smap-spd_smap_windspeed_139kts_54p35_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/smap.tc.windspeed.imagery_clean/20210926_085600_WP202021_smap-spd_smap_windspeed_139kts_54p35_res1p0-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: WP, 20, 2021092606,   , BEST,   0, 188N, 1367E, 145,  908, ST,  34, N
 final_storm_name: MINDULLE
 interpolated_time: 2021-09-26 08:59:00
 invest_number: 99
-original_source_filenames:
-- RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc
 parser_name: bdeck_parser
 pressure: 914.02
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/WP/WP202021/png_clean/windspeed/smap/20210926_085600_WP202021_smap-spd_smap_windspeed_139kts_54p35_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp202021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp202021.dat
 storm_basin: WP

--- a/tests/outputs/smap.tc.windspeed.imagery_clean/20210926_210400_WP202021_smap-spd_smap_windspeed_104kts_74p70_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/smap.tc.windspeed.imagery_clean/20210926_210400_WP202021_smap-spd_smap_windspeed_104kts_74p70_res1p0-akima-clean.png.yaml
@@ -18,13 +18,13 @@ deck_line: WP, 20, 2021092700,   , BEST,   0, 196N, 1367E, 100,  952, TY,  34, N
 final_storm_name: MINDULLE
 interpolated_time: 2021-09-26 21:06:00
 invest_number: 99
-original_source_filenames:
-- RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc
 parser_name: bdeck_parser
 pressure: 949.82
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/WP/WP202021/png_clean/windspeed/smap/20210926_210400_WP202021_smap-spd_smap_windspeed_104kts_74p70_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- RSS_smap_wind_daily_2021_09_26_NRT_v01.0.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp202021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bwp202021.dat
 storm_basin: WP

--- a/tests/outputs/smos.tc.windspeed.imagery_clean/20200216_124335_SH162020_smos-spd_smos_windspeed_75kts_38p89_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/smos.tc.windspeed.imagery_clean/20200216_124335_SH162020_smos-spd_smos_windspeed_75kts_38p89_res1p0-akima-clean.png.yaml
@@ -18,7 +18,7 @@ deck_line: SH, 16, 2020021612,   , BEST,   0, 202S,  750E,  75,  978, TY,  34, N
 final_storm_name: GABEKILE
 interpolated_time: 2020-02-16 12:45:00
 invest_number: 94
-original_source_filenames:
+source_file_names:
 - SM_OPER_MIR_SCNFSW_20200216T120839_20200216T135041_110_001_7.nc
 parser_name: bdeck_parser
 pressure: 977.82

--- a/tests/outputs/ssmi.tc.37pct.imagery_clean/20200519_080900_IO012020_ssmi_F15_37pct_105kts_48p73_res1p0-arH37-clean.png.yaml
+++ b/tests/outputs/ssmi.tc.37pct.imagery_clean/20200519_080900_IO012020_ssmi_F15_37pct_105kts_48p73_res1p0-arH37-clean.png.yaml
@@ -21,7 +21,7 @@ deck_line: IO, 01, 2020051906,   , BEST,   0, 165N,  869E, 110,  941, TY,  34, N
 final_storm_name: AMPHAN
 interpolated_time: 2020-05-19 09:01:00
 invest_number: 91
-original_source_filenames:
+source_file_names:
 - US058SORB-DEFspp.sdrmi_f15_d20200519_s080800_e095300_r05633_cfnoc.def
 parser_name: bdeck_parser
 pressure: 946.03

--- a/tests/outputs/ssmis.tc.color91.imagery_clean/20200519_095800_IO012020_ssmis_F16_color91_103kts_98p36_res1p0-arH91-clean.png.yaml
+++ b/tests/outputs/ssmis.tc.color91.imagery_clean/20200519_095800_IO012020_ssmis_F16_color91_103kts_98p36_res1p0-arH91-clean.png.yaml
@@ -21,7 +21,7 @@ deck_line: IO, 01, 2020051906,   , BEST,   0, 165N,  869E, 110,  941, TY,  34, N
 final_storm_name: AMPHAN
 interpolated_time: 2020-05-19 10:01:00
 invest_number: 91
-original_source_filenames:
+source_file_names:
 - US058SORB-RAWspp.sdris_f16_d20200519_s084400_e102900_r85579_cfnoc.raw
 parser_name: bdeck_parser
 pressure: 947.69

--- a/tests/outputs/viirs.tc.Infrared-Gray.imagery_clean/20210209_074210_SH192021_viirs_noaa-20_Infrared-Gray_127kts_100p00_res1p0-akima-clean.png.yaml
+++ b/tests/outputs/viirs.tc.Infrared-Gray.imagery_clean/20210209_074210_SH192021_viirs_noaa-20_Infrared-Gray_127kts_100p00_res1p0-akima-clean.png.yaml
@@ -18,16 +18,16 @@ deck_line: SH, 19, 2021020906,   , BEST,   0, 140S,  835E, 130,  930, ST,  34, N
 final_storm_name: FARAJI
 interpolated_time: 2021-02-09 07:45:10.312834
 invest_number: 90
-original_source_filenames:
-- VJ102IMG.A2021040.0736.002.2021040145245.nc
-- VJ103IMG.A2021040.0736.002.2021040142228.nc
-- VJ102IMG.A2021040.0742.002.2021040143010.nc
-- VJ103IMG.A2021040.0742.002.2021040140938.nc
 parser_name: bdeck_parser
 pressure: 932.75
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2021/SH/SH192021/png_clean/Infrared-Gray/noaa-20/20210209_074210_SH192021_viirs_noaa-20_Infrared-Gray_127kts_100p00_res1p0-akima-clean.png
 recenter_type: akima
 sector_type: tc
+source_file_names:
+- VJ102IMG.A2021040.0736.002.2021040145245.nc
+- VJ103IMG.A2021040.0736.002.2021040142228.nc
+- VJ102IMG.A2021040.0742.002.2021040143010.nc
+- VJ103IMG.A2021040.0742.002.2021040140938.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bsh192021.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bsh192021.dat
 storm_basin: SH


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#250

# Reviewer Instructions
* Please confirm merge is into 'main' branch from 'v1.10.3-release'
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates.

# Summary
Changes for version 1.10.3 update on repo recenter_tc.

See NRLMMD-GEOIPS/geoips#250 for additional repositories included in this update.

# Testing Instructions
Install GEOIPS and clone v1.10.3-release branch for:
* recenter_tc
* geoips
* data_fusion (for full_test.sh to pass)
* geoips_clavrx (for full_test.sh to pass)

main branch:
* test repos (obtained through full_install.sh)

Tests should return 0:
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_install.sh
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_test.sh

# Output


# Post Merge Steps
Once this PR has been merged, v1.10.3 will be tagged/released on the recenter_tc main branch.