### PR TITLE
v1.11.2 recenter_tc - VERSION RELEASE - fix missing pressure error

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,7 @@ Version 1.11
 .. toctree::
    :maxdepth: 1
 
+   v1_11_2
    v1_11_0
 
 Version 1.10

--- a/docs/source/releases/v1_11_2.rst
+++ b/docs/source/releases/v1_11_2.rst
@@ -1,0 +1,30 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.11.2 (2023-09-15)
+***************************
+
+* Bug Fix: Akima recentering failing due to insufficient pressure data.
+
+Bug Fixes
+=========
+
+Akima recentering failing due to insufficient pressure data
+-----------------------------------------------------------
+
+*From GEOIPS#62: 2023-08-24, Akima pressure recentering failing*
+
+If pressure interpolation fails (raising a ValueError), set recenter_pressure to -9999.
+
+::
+
+    modified: recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -540,9 +540,17 @@ def recenter_with_akima(sect_xarray, area_def):
         times_arr[:-1][vmax_arr != -9999], vmax_arr[vmax_arr != -9999], ctime_arr
     )[0].astype(float)
     pres_arr = numpy.array(pressures[:-1])
-    recenter_pressure = interpolate(
-        times_arr[:-1][pres_arr != -9999], pres_arr[pres_arr != -9999], ctime_arr
-    )[0].astype(float)
+    try:
+        recenter_pressure = interpolate(
+            times_arr[:-1][pres_arr != -9999], pres_arr[pres_arr != -9999], ctime_arr
+        )[0].astype(float)
+    except ValueError:
+        # Sometimes we lack enough pressure data to interpolate.
+        # Rather than hardcoding logic that determines when we should attempt
+        # to interpolate pressure, always attempt interpolating.
+        # It does not add much overhead, and will raise a ValueError.
+        # If interpolation fails and raises a ValueError, set pressure to -9999
+        recenter_pressure = -9999
     new_fields = area_def.sector_info.copy()
     # YAML output fails on numpy.float64, so cast as float
     new_fields["clat"] = round(float(recenter_clat), 2)


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#346

# Reviewer Instructions
* Please confirm merge is into 'main' branch from 'v1.11.3-release'
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates.

# Summary
Changes for version 1.11.2, uploaded with
1.11.3 update on repo recenter_tc.
See release notes in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#346 for additional repositories included in this update.

# Testing Instructions
<!-- Remove this section if this is a repo without tests-->
Install GEOIPS and clone v1.11.3-release branch for:
* recenter_tc
<!-- include additional repositories that must also be updated for tests to pass -->

Tests should return 0:
# The 'full_test.sh' will test ALL repos and test data available on github.com
$GEOIPS_PACKAGES_DIR/geoips/tests/integration_tests/full_test.sh
# Potentially only a subset of the 'test_all.sh' tests in each repo will work:
$GEOIPS_PACKAGES_DIR/recenter_tc/tests/test_all.sh

# Output
<!-- Remove this section if this is a repo without outputs -->
<!-- Copy/paste appropriate output here if you installed and ran updates on open source -->

# Post Merge Steps
Once this PR has been merged, v1.11.2
will be tagged/released on the recenter_tc main branch.