### PR TITLE
382 raise error for duplicate plugins

### DIFF
--- a/docs/source/releases/v1_11_7a0.rst
+++ b/docs/source/releases/v1_11_7a0.rst
@@ -14,6 +14,22 @@ Version 1.11.7a0 (2023-10-06)
 *****************************
 
 * Refactor: Update recenter-tc to use 'output_checkers' interface.
+* BugFix: Rename archer_image.py:name to 'archer_image'
+
+Bug Fixes
+=========
+
+Rename archer_image.py:name to 'archer_image'
+---------------------------------------------
+
+With the addition of 382 Raise Error For Duplicate Plugins PR on GeoIPS, we have tested
+for duplicate plugin names and found that archer_fix.py:name and archer_image.py:name
+were both named 'archer_fix'. We have changed the name in archer_image to 'archer_image'
+to fix this.
+
+::
+
+    modified: recenter_tc/recenter_tc/plugins/modules/filename_formatters/archer_image.py
 
 Refactoring Updates
 ===================

--- a/recenter_tc/plugins/modules/filename_formatters/archer_image.py
+++ b/recenter_tc/plugins/modules/filename_formatters/archer_image.py
@@ -19,7 +19,7 @@ from recenter_tc.filenames.base_paths import PATHS as gpaths
 
 interface = "filename_formatters"
 family = "xarray_metadata_to_filename"
-name = "archer_fix"
+name = "archer_image"
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

# Related Issues
fixes NRLMMD-GEOIPS/geoips#382

# Testing Instructions
Run geoips/geoips/create_plugin_registries.py to ensure that all plugins have unique names. Will raise a 'PluginRegistryError' otherwise.

# Summary
With the addition of 382 Raise Error For Duplicate Plugins PR on GeoIPS, we have tested
for duplicate plugin names and found that archer_fix.py:name and archer_image.py:name
were both named 'archer_fix'. We have changed the name in archer_image to 'archer_image'
to fix this.

    modified: recenter_tc/recenter_tc/plugins/modules/filename_formatters/archer_image.py
