### PR TITLE
fixed print_area_def bug in recenter_tc.py

### DIFF
--- a/docs/source/releases/v1_12_2a0.rst
+++ b/docs/source/releases/v1_12_2a0.rst
@@ -13,20 +13,39 @@
 Version 1.12.2a0 (2024-29-03)
 *****************************
 
-* Update: Update logging functions to use ``log_with_emphasis`` in ``geoips`` 
-
+* Update: Update logging functions to use ``log_with_emphasis`` in ``geoips``
+* Bug Fix: Re-added GeoIPS ``single_source:print_area_def`` to ``recenter_tc.py``
 
 Updates
 =======
 
-Update logging functions to use ``log_with_emphasis`` in ``geoips`` 
+Update logging functions to use ``log_with_emphasis`` in ``geoips``
 --------------------------------------------------------------------
 
-Removed manual logging with lots of "********************" string literals and 
-replaces it with a built in logging function implemented in geoips. 
+Removed manual logging with lots of "********************" string literals and
+replaces it with a built in logging function implemented in geoips.
 
-This update does not change any functionality, but some logged out statements 
+This update does not change any functionality, but some logged out statements
 will now have slightly different formatting.
+
+::
+
+    modified: recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+
+Bug Fix
+=======
+
+Re-added GeoIPS ``single_source:print_area_def`` to ``recenter_tc.py``
+----------------------------------------------------------------------
+
+*Stems from GEOIPS#464, 2024-04-15: Finish Log with Emphasis Function*
+
+The PR mentioned above improved the log with emphasis function but ended up removing
+``geoips/plugins/modules/procflows/single_source.py:print_area_def`` function as it was
+not used within GeoIPS. However, when running ``create_plugin_registries``, we get an
+error within ``recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py`` as that
+module uses the aforementioned function. This Bug Fix re-implements ``print_area_def``
+and refactors that function to use the ``log_with_emphasis`` function instead.
 
 ::
 

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -16,7 +16,6 @@ from os.path import dirname
 
 import logging
 
-from geoips.plugins.modules.procflows.single_source import print_area_def
 from geoips.filenames.base_paths import make_dirs
 from geoips.interfaces import filename_formatters
 from geoips.commandline.log_setup import log_with_emphasis
@@ -32,6 +31,14 @@ LOG = logging.getLogger(__name__)
 interface = "sector_adjusters"
 family = "list_xarray_list_variables_to_area_def_out_fnames"
 name = "recenter_tc"
+
+
+def print_area_def(area_def, print_str):
+    """Print the supplied pyresample area definition using log with emphasis."""
+    messages = [print_str, area_def]
+    for key, value in area_def.sector_info.items():
+        messages.append(f"{key}: {value}")
+    log_with_emphasis(LOG.info, *messages)
 
 
 def run_archer(xarray_obj, varname):

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -35,7 +35,7 @@ name = "recenter_tc"
 
 def print_area_def(area_def, print_str):
     """Print the supplied pyresample area definition using log with emphasis."""
-    messages = [print_str, area_def]
+    messages = [print_str, str(area_def)]
     for key, value in area_def.sector_info.items():
         messages.append(f"{key}: {value}")
     log_with_emphasis(LOG.info, *messages)


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] Required ***documentation*** added for new/modified functionality
* [x] Required ***release notes*** added for new/modified functionality
* [x] NO REQUIRED ***updates to other repos*** (explain why not required)

https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md

# Related Issues
No issue was made as it was a simple fix, but this stems from the changes made in NRLMMD-GEOIPS/geoips#464
See NRLMMD-GEOIPS/geoips#497

# Testing Instructions
Run ``./recenter_tc/tests/test_all.sh`` and get an output of 0.

# Summary
The PR mentioned above improved the log with emphasis function but ended up removing
``geoips/plugins/modules/procflows/single_source.py:print_area_def`` function as it was
not used within GeoIPS. However, when running ``create_plugin_registries``, we get an
error within ``recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py`` as that
module uses the aforementioned function. This Bug Fix re-implements ``print_area_def``
and refactors that function to use the ``log_with_emphasis`` function instead.

    modified: recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
