### PR TITLE
v1.12.2 recenter_tc - VERSION RELEASE - short summary

### DIFF
--- a/docs/source/releases/index.rst
+++ b/docs/source/releases/index.rst
@@ -22,6 +22,8 @@ Version 1.12
 .. toctree::
    :maxdepth: 1
 
+   v1_12_3
+   v1_12_2
    v1_12_2a0
 
 Version 1.11
@@ -29,6 +31,7 @@ Version 1.11
 
 .. toctree::
    :maxdepth: 1
+
 
    v1_11_7
    v1_11_7a0

--- a/docs/source/releases/v1_12_2.rst
+++ b/docs/source/releases/v1_12_2.rst
@@ -10,15 +10,19 @@
  | # # # for more details. If you did not receive the license, for more information see:
  | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
 
-Please see
-https://github.com/NRLMMD-GEOIPS/geoips/blob/main/CHANGELOG_TEMPLATE.rst
-for instructions on updating release notes appropriately
-with each PR.
+Version 1.12.2 (2024-04-24)
+**************************************
 
-The release note that is currently, actively being updated in
-all geoips plugin repositories is referenced in the file:
+Release Updates
+===============
 
-* https://github.com/NRLMMD-GEOIPS/geoips/blob/main/update_this_release_note
+Add 1.12.2 release note
+---------------------------
 
-* Please add all release notes for the current PR in the file referenced
-  within ``update_this_release note``.
+*From issue GEOIPS#493: 2024-04-24, version update*
+
+::
+
+    modified: CHANGELOG.rst
+    new file: docs/source/releases/v1_12_2.rst
+    modified: docs/source/releases/index.rst

--- a/docs/source/releases/v1_12_3.rst
+++ b/docs/source/releases/v1_12_3.rst
@@ -1,0 +1,52 @@
+ | # # # Distribution Statement A. Approved for public release. Distribution unlimited.
+ | # # #
+ | # # # Author:
+ | # # # Naval Research Laboratory, Marine Meteorology Division
+ | # # #
+ | # # # This program is free software: you can redistribute it and/or modify it under
+ | # # # the terms of the NRLMMD License included with this program. This program is
+ | # # # distributed WITHOUT ANY WARRANTY; without even the implied warranty of
+ | # # # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the included license
+ | # # # for more details. If you did not receive the license, for more information see:
+ | # # # https://github.com/U-S-NRL-Marine-Meteorology-Division/
+
+Version 1.12.3 (2024-03-02)
+***************************
+
+* Installation Updates
+
+  * Update to poetry pyproject.toml
+* Release Updates
+
+  * Add release note for v1.12.3
+
+
+Installation Updates
+====================
+
+Update to poetry pyproject.toml
+-------------------------------
+
+Also update to standard CHANGELOG.rst
+
+::
+
+  modified: pyproject.toml
+  new file: recenter_tc/_version.py
+  modified: CHANGELOG.rst
+
+Release Process
+===============
+
+Add release note for v1.12.3
+----------------------------
+
+*From GEOIPS#458: 2024-02-17, 1.12.1 release*
+
+All updates until the next release (v1.12.3) will be included in
+this release note.
+
+::
+
+  modified: docs/source/releases/v1_12_3.rst
+  modified: docs/source/releases/index.rst

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,60 +1,45 @@
-[build-system]
-requires = ["setuptools>=61.2", "setuptools-scm"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools.packages]
-find = { namespaces = false }
-
-[tool.setuptools.package-dir]
-"" = "."
-
-[tool.setuptools.package-data]
-"*" = [
-    "plugins/*.yaml",
-    "plugins/*/*.yaml",
-    "plugins/*/*/*.yaml",
-    "plugins/*/*/*/*.yaml",
-    "plugins/*/*/*/*/*.yaml",
-    "plugins/*.txt",
-    "plugins/*/*.txt",
-    "plugins/*/*/*.txt",
-    "plugins/*/*/*/*.txt",
-    "plugins/*/*/*/*/*.txt",
-]
-
-[tool.setuptools.dynamic]
-entry-points = { file = ["entry-points.ini"] }
-
-[tool.setuptools_scm]
-"version_scheme" = "post-release"      # Use current version .postN vs incrementing
-"local_scheme" = "no-local-version"    # Don't include hash, or date, just postN
-"write_to" = "recenter_tc/_version.py" # Write an actual file
-
-[project]
-name = "recenter_tc"
+[tool.poetry]
+name = "recenter_tc"                                          # geoips package available at the root of the project
+version = "0.0.0"
+description = "recenter_tc GeoIPS Plugin Package"
 authors = []
-description = "TC Recentering GeoIPS Plugin Package"
 readme = "README.md"
-requires-python = ">=3.9"
 keywords = []
-license = { file = "LICENSE" }
-classifiers = ["Programming Language :: Python :: 3"]
-dynamic = ["version"]
-
-dependencies = [
-    "archer @ git+https://github.com/mindyls/archer.git",
-    "akima86 @ git+https://github.com/NRLMMD-GEOIPS/akima86.git",
+license = "LICENSE"   # required
+classifiers = [ # // list of PyPI trove classifiers to describe the project
+    "Programming Language :: Python :: 3",
 ]
+repository = "https://github.com/NRLMMD-GEOIPS/recenter_tc" #optional
+#documentation = "set the url"
+include = ["**/*.txt", "**/*.py", "**/*.yaml"]
 
-[project.entry-points."geoips.plugin_packages"]
+# uses current version .postN and not incrementing
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+metadata = false # don't include local-version hash; date doesn't appear by deafult
+style = "pep440" # pep440 is default; can rmeove later on; used for : keeping 0.0.8 as the default install until 0.0.9 is out
+#style = "semver"
+#tag-branch = "feature-poetry"
+strict = false
+pattern = "(?x)^((?P<epoch>\\d+)!)?(?P<base>\\d+(\\.\\d+)*)([-._]?((?P<stage>[a-zA-Z]+)[-._]?(?P<revision>\\d+)?))?(\\+(?P<tagged_metadata>.+))?$"
+
+[tool.poetry-dynamic-versioning.substitution]
+files = ["*/_version.py"]
+
+# This is where you would specify a pre-build script from pyproject.toml/poetry.
+# [tool.poetry.build]
+# generate-setup-file = false  # I have no idea what this does
+# script = "build.py"  # This gets called as a python script prior to running build steps
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"                          # object used to perform the build process
+
+[tool.poetry.dependencies] # must download to run
+python = ">=3.10"       # mandatory to declare the required python version
+archer = { git = "https://github.com/mindyls/archer.git" }
+akima86 = { git = "https://github.com/NRLMMD-GEOIPS/akima86.git" }
+
+[tool.poetry.plugins."geoips.plugin_packages"]
 "recenter_tc" = "recenter_tc"
-
-[project.entry-points."geoips.sector_adjusters"]
-"recenter_tc" = "recenter_tc.plugins.modules.sector_adjusters.recenter_tc"
-
-[project.entry-points."geoips.filename_formatters"]
-"archer_fix" = "recenter_tc.plugins.modules.filename_formatters.archer_fix"
-"archer_image" = "recenter_tc.plugins.modules.filename_formatters.archer_image"
-
-[project.entry-points."geoips.output_checkers"]
-"fdeck" = "recenter_tc.plugins.modules.output_checkers.fdeck"


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#529
required to close NRLMMD-GEOIPS/geoips#506

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.12.2-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.12.2, uploaded with
1.12.2 update on repo recenter_tc.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#529 for additional repositories included in this update.
See NRLMMD-GEOIPS/geoips#506 for dev updates included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#529 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#529 for test output.

# Post Merge Steps
Once this PR has been merged, v1.12.2
will be tagged/released on the recenter_tc main branch.