### PR TITLE
312 output update abi.tc.visible.imagery clean

### DIFF
--- a/docs/source/releases/latest/312-output-update-abi.tc.Visible.imagery_clean.yaml
+++ b/docs/source/releases/latest/312-output-update-abi.tc.Visible.imagery_clean.yaml
@@ -1,0 +1,11 @@
+testing:
+- description: |
+    This PR stems from PR #427 on the GeoIPS open source repo. Essentially, the updates
+    we made to certain readers affected the yaml output of
+    abi.tc.Visible.imagery_clean.sh. This was a very simple PR and was just an update
+    to the aforementioned output. There are two lines added to the yaml file which stem
+    from new metadata added to our xarray object.
+  files:
+    modified:
+      - tests/outputs/abi.tc.Visible.imagery_clean/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png.yaml
+  title: '312-output-update-abi.tc.Visible.imagery_clean'

--- a/tests/outputs/abi.tc.Visible.imagery_clean/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png.yaml
+++ b/tests/outputs/abi.tc.Visible.imagery_clean/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png.yaml
@@ -28,6 +28,8 @@ pressure: 952.47
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2020/AL/AL202020/png_clean/Visible/goes-16/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png
 recenter_type: B03Ref
 sector_type: tc
+source_file_names:
+- OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bal202020.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bal202020.dat
 storm_basin: AL


### PR DESCRIPTION
# Reviewer Checklist

* [x] Required ***existing tests*** pass (ie full_test.sh, others as appropriate)
* [x] NO REQUIRED ***unit tests*** (explain why not required)
* [x] NO REQUIRED ***integration tests*** (explain why not required)
* [x] NO REQUIRED ***documentation*** (explain why not required)
* [x] Required ***release notes*** added for new/modified functionality
* [x] Required ***updates to other repos*** complete

# Related Issues
fixes NRLMMD-GEOIPS/geoips#312

# Testing Instructions
Run full test on [PR #427](https://github.com/NRLMMD-GEOIPS/geoips/pull/427).

# Summary
This PR stems from [PR #427](https://github.com/NRLMMD-GEOIPS/geoips/pull/427) on the GeoIPS open source repo. Essentially, the updates
we made to certain readers affected the yaml output of
abi.tc.Visible.imagery_clean.sh. This was a very simple PR and was just an update
to the aforementioned output. There are two lines added to the yaml file which stem
from new metadata added to our xarray object.

Files Modified:

    tests/outputs/abi.tc.Visible.imagery_clean/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png.yaml

# Full Script Output

```
(geoips) (base) [evan@spring scripts]$ ./abi.tc.Visible.imagery_clean.sh 
14_211644 run_procflow.py:47   INTERACTIVE: 


Starting single_source procflow...


14_211644 run_procflow.py:62   INTERACTIVE: 


Running on filenames: ['/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C01_G16_s20202621950205_e20202621959513_c20202621959567.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C02_G16_s20202621950205_e20202621959513_c20202621959546.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C03_G16_s20202621950205_e20202621959513_c20202621959570.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C04_G16_s20202621950205_e20202621959513_c20202621959534.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C05_G16_s20202621950205_e20202621959513_c20202621959562.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C06_G16_s20202621950205_e20202621959518_c20202621959556.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C07_G16_s20202621950205_e20202621959524_c20202621959577.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C08_G16_s20202621950205_e20202621959513_c20202621959574.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C09_G16_s20202621950205_e20202621959518_c20202621959588.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C10_G16_s20202621950205_e20202621959524_c20202621959578.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C11_G16_s20202621950205_e20202621959513_c20202621959583.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C12_G16_s20202621950205_e20202621959518_c20202621959574.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C13_G16_s20202621950205_e20202621959525_c20202622000005.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C14_G16_s20202621950205_e20202621959513_c20202622000009.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C15_G16_s20202621950205_e20202621959518_c20202621959594.nc', '/local/share/geoips/test_data/test_data_noaa_aws/data/goes16/20200918/1950/OR_ABI-L1b-RadF-M6C16_G16_s20202621950205_e20202621959524_c20202622000001.nc']


14_211644 single_source.py:1852 INTERACTIVE: Reading metadata from dataset with reader 'abi_netcdf'...
14_211645 single_source.py:1353 INTERACTIVE: Getting all area defs from command line args:
14_211645 single_source.py:1356 INTERACTIVE:   sector_list: None
14_211645 single_source.py:1359 INTERACTIVE:   tcdb_sector_list: None
14_211645 single_source.py:1362 INTERACTIVE:   tcdb: False
14_211645 single_source.py:1365 INTERACTIVE:   trackfile_sector_list: None
14_211645 single_source.py:1368 INTERACTIVE:   trackfiles: ['/home/evan/geoips/geoips_packages/geoips/tests/sectors/tc_bdecks/bal202020.dat']
14_211645 single_source.py:1371 INTERACTIVE:   trackfile_parser: bdeck_parser
14_211645 single_source.py:1374 INTERACTIVE:   tc_spec_template: None
14_211646 single_source.py:1983 INTERACTIVE: Reading sectored dataset for self registered products with reader 'abi_netcdf'...
14_211649   abi_netcdf.py:813  INTERACTIVE: Done with geolocation for tc2020al20teddy
14_211653 single_source.py:2015 INTERACTIVE: Sectoring xarrays, variables ['B03Ref', 'solar_zenith_angle']...
14_211653 single_source.py:2054 INTERACTIVE: Producing sectored outputs...
14_211653 single_source.py:2083 INTERACTIVE: Sectoring padded xarrays...
14_211654 single_source.py:2103 INTERACTIVE: Adjusting sectors with recenter_tc...
14_211654    log_setup.py:49   INTERACTIVE: *****************************************
14_211654    log_setup.py:54   INTERACTIVE: ** Attempting to recenter TC sector... **
14_211654    log_setup.py:55   INTERACTIVE: *****************************************
14_211654    log_setup.py:56   INTERACTIVE: 

14_211654    log_setup.py:49   INTERACTIVE: *******************************************
14_211654    log_setup.py:54   INTERACTIVE: ** Running AKIMA center interpolation... **
14_211654    log_setup.py:55   INTERACTIVE: *******************************************
14_211654    log_setup.py:56   INTERACTIVE: 

14_211654    log_setup.py:49   INTERACTIVE: ****************************************************************************
14_211654    log_setup.py:54   INTERACTIVE: ** Interpolating new center from 56best track positions, closest position **
14_211654    log_setup.py:54   INTERACTIVE: ** 34...                                                                  **
14_211654    log_setup.py:55   INTERACTIVE: ****************************************************************************
14_211654    log_setup.py:56   INTERACTIVE: 

           0           1
           0           1
           0           1
           0           1
14_211654    log_setup.py:49   INTERACTIVE: ************************************
14_211654    log_setup.py:54   INTERACTIVE: ** Akima interpolation successful **
14_211654    log_setup.py:55   INTERACTIVE: ************************************
14_211654    log_setup.py:56   INTERACTIVE: 

14_211654    log_setup.py:49   INTERACTIVE: *********************************
14_211654    log_setup.py:54   INTERACTIVE: ** Attempting to run ARCHER... **
14_211654    log_setup.py:55   INTERACTIVE: *********************************
14_211654    log_setup.py:56   INTERACTIVE: 

14_211654    log_setup.py:49   INTERACTIVE: *********************************
14_211654    log_setup.py:54   INTERACTIVE: ** Running ARCHER on B03Ref... **
14_211654    log_setup.py:55   INTERACTIVE: *********************************
14_211654    log_setup.py:56   INTERACTIVE: 

14_211654  recenter_tc.py:223  INTERACTIVE: ARCHERSUCCESS Writing ARCHER image: /home/evan/geoips/geoips_packages/outdirs/preprocessed/archer/image/tc2020/AL/AL202020/png/archer/20200918.1950_tc2020al20teddy_archer_abi_B03Ref_Vis_noaa_goes-16.png
Reducing resolution by factors of 4 , 2
Computing center-fix on full image...
Regridding data to equal lon/lat aspect ratio ... 
Calculating spiral center ...
Calculating ring center ... 
sensor_type =  Vis
Radius (deg) = 0.50 0.45 0.40 0.35 0.30 0.25 0.20 0.15 0.10 0.05 
fdeck output:
AL, 20, 2009181950,  70, VISI,          C,  , 2289N,  5670W,      , 3,    ,  ,     ,  ,     ,    ,     ,     ,     ,     ,     ,  ,  ,  ,  ,  ,    ,    ,  ,  CIMS, AUT,    ,             ,             ,    ,     ,                        v, irad=0.15 | r50=0.48 | r95=1.36 | ep=-99 | src=ARCH
14_211741  recenter_tc.py:240  INTERACTIVE: ARCHERSUCCESS Wrote ARCHER fdeck: /home/evan/geoips/geoips_packages/outdirs/preprocessed/archer/fix/20200918.1950_tc2020al20teddy_archer_abi_B03Ref_Vis_noaa_goes-16_20L_FIX
14_211741    log_setup.py:49   INTERACTIVE: ***************************
14_211741    log_setup.py:54   INTERACTIVE: ** ARCHER run successful **
14_211741    log_setup.py:55   INTERACTIVE: ***************************
14_211741    log_setup.py:56   INTERACTIVE: 

14_211741    log_setup.py:49   INTERACTIVE: *********************************************
14_211741    log_setup.py:54   INTERACTIVE: ** Running ARCHER on solar_zenith_angle... **
14_211741    log_setup.py:55   INTERACTIVE: *********************************************
14_211741    log_setup.py:56   INTERACTIVE: 

14_211741    log_setup.py:49   INTERACTIVE: *****************************
14_211741    log_setup.py:54   INTERACTIVE: ** ARCHER run unsuccessful **
14_211741    log_setup.py:55   INTERACTIVE: *****************************
14_211741    log_setup.py:56   INTERACTIVE: 

14_211741    log_setup.py:49   INTERACTIVE: *************************
14_211741    log_setup.py:54   INTERACTIVE: ** Done running ARCHER **
14_211741    log_setup.py:55   INTERACTIVE: *************************
14_211741    log_setup.py:56   INTERACTIVE: 

14_211741    log_setup.py:49   INTERACTIVE: ********************************
14_211741    log_setup.py:54   INTERACTIVE: ** Done recentering TC sector **
14_211741    log_setup.py:55   INTERACTIVE: ********************************
14_211741    log_setup.py:56   INTERACTIVE: 

14_211741 single_source.py:1550 INTERACTIVE: Applying algorithms and interpolation...
14_211741 single_source.py:247  INTERACTIVE: Resectoring xarrays without padding...
14_211741 single_source.py:1617 INTERACTIVE:   Applying interpolators...
14_211741 single_source.py:756  INTERACTIVE:   Interpolating data with interpolator 'interp_nearest' args '{'varlist': ['solar_zenith_angle', 'B03Ref']}'...
14_211743 single_source.py:756  INTERACTIVE:   Interpolating data with interpolator 'interp_nearest' args '{'varlist': []}'...
14_211743 single_source.py:1640 INTERACTIVE:   Applying algorithms after interpolators...
14_211743 single_source.py:520  INTERACTIVE:   Applying 'list_numpy_to_numpy' family algorithm 'single_channel' to data...
14_211743 single_source.py:1660 INTERACTIVE:   Setting metadata on final xarray...
14_211743 single_source.py:2270 INTERACTIVE: Required coverage 10 for product Visible, actual coverage 100.0
14_211743 single_source.py:1156 INTERACTIVE: Producing product 'Visible' final outputs as type 'imagery_clean'...
14_211743 single_source.py:1200 INTERACTIVE:   Producing 'image' family final outputs 'imagery_clean'...
14_211744 single_source.py:2335 INTERACTIVE: 


Processing complete! Checking outputs...


14_211744 single_source.py:2375 INTERACTIVE: 


The following products were produced from procflow single_source.py


14_211744 single_source.py:2380 INTERACTIVE:     SINGLESOURCESUCCESS ${GEOIPS_OUTDIRS}/preprocessed/tcwww/tc2020/AL/AL202020/png_clean/Visible/goes-16/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png
14_211744 single_source.py:2380 INTERACTIVE:     SINGLESOURCESUCCESS ${GEOIPS_OUTDIRS}/preprocessed/tcwww/tc2020/AL/AL202020/metadata/sector_information/20200918/20200918_195020_AL202020_abi_goes-16_Visible_110kts_100p00_res1p0-arB03Ref-clean.png.yaml
14_211744 single_source.py:2391 INTERACTIVE: READER_NAME: abi_netcdf
14_211744 single_source.py:2392 INTERACTIVE: PRODUCT_NAME: Visible
14_211744 single_source.py:2393 INTERACTIVE: NUM_PRODUCTS: 2
14_211744 single_source.py:2394 INTERACTIVE: NUM_DELETED_PRODUCTS: 0
14_211744 run_procflow.py:68   INTERACTIVE: Completed geoips PROCFLOW single_source processing, done!
14_211744 run_procflow.py:74   INTERACTIVE: Total time: 0:01:00.267294
14_211744 run_procflow.py:94   INTERACTIVE: Return value: 0
```
