### PR TITLE
Use akima86 from pypi

### DIFF
--- a/docs/source/releases/1.16.1/use-akima86-from-pypi-1.16.1.yaml
+++ b/docs/source/releases/1.16.1/use-akima86-from-pypi-1.16.1.yaml
@@ -2,7 +2,7 @@ bug fix:
 - title: 'Switch to akima86 from pypi rather than git'
   description: |
     Updated the version of akima86 in pyproject.toml from pointing to
-    a branch on the git repository to, instead, use \"*\" and pull from
+    a branch on the git repository to, instead, use * and pull from
     pypi. Akima86 recently became buildable using meson and has been
     uploaded to pypi.
   files:

--- a/docs/source/releases/1.16.1/use-akima86-from-pypi-1.16.1.yaml
+++ b/docs/source/releases/1.16.1/use-akima86-from-pypi-1.16.1.yaml
@@ -1,0 +1,22 @@
+bug fix:
+- title: 'Switch to akima86 from pypi rather than git'
+  description: |
+    Updated the version of akima86 in pyproject.toml from pointing to
+    a branch on the git repository to, instead, use \"*\" and pull from
+    pypi. Akima86 recently became buildable using meson and has been
+    uploaded to pypi.
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'pyproject.toml'
+  related-issue:
+    number: null
+    repo_url: ''
+  date:
+    start: 2025-06-20
+    finish: 2025-06-20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ python = ">=3.10"       # mandatory to declare the required python version
 # geoips pyproject.toml as soon as we resolve the meson builds for all the
 # fortran-based plugins.
 archer = { git = "https://github.com/mindyls/archer.git" }
-akima86 = { git = "https://github.com/NRLMMD-GEOIPS/akima86.git" }
+akima86 = "*"
 
 [tool.poetry.plugins."geoips.plugin_packages"]
 "recenter_tc" = "recenter_tc"


### PR DESCRIPTION


## ✨ Summary

Update pyproject.toml to collect akima86 from pypi rather than from a git repository. akima86 has been released to pypi, finally, and this solves install problems for numpy 2.0+.

---

## ✅ Checklist for Reviewer Reference (filled out by PR Author)

- [x] **Tests**: All tests and CI pass (e.g., full, base, extra, etc.)
    - [x] **Full test**: Yes, full test *is passing*.
- [x] **Integration Tests**: Integration tests added/updated for new/modified functionality *OR* no new functionality
- [x] **Other Repos**: I have updated other repositories to handle this change *OR* my package doesn't impact other plugin packages.

For more details, please see our [review template](https://github.com/NRLMMD-GEOIPS/.github/blob/main/.github/review-template.md) 💌

---
