### PR TITLE
1.18.0 recenter_tc - VERSION RELEASE - storm_id updates, add archer_info to metadata outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Install recenter_tc package
     source $GEOIPS_CONFIG_FILE
     git clone https://github.com/NRLMMD-GEOIPS/recenter_tc $GEOIPS_PACKAGES_DIR/recenter_tc
     pip install -e $GEOIPS_PACKAGES_DIR/recenter_tc
-    create_plugin_registries
+    geoips config create-registries
 ```
 
 Test recenter_tc installation
@@ -84,9 +84,12 @@ Test recenter_tc installation
     # Ensure GeoIPS Python environment is enabled.
 
     # If you have the full ABI and AMSR2 test datasets:
+    geoips config install test_data_abi
+    geoips config install test_data_amsr2
     $GEOIPS_PACKAGES_DIR/recenter_tc/tests/scripts/abi.tc.Visible.imagery_clean.sh
     $GEOIPS_PACKAGES_DIR/recenter_tc/tests/scripts/amsr2.tc.color37.imagery_clean.sh
 
     # If you have all test data repos available:
-    $GEOIPS_PACKAGES_DIR/recenter_tc/tests/test_all.sh
+    cd $GEOIPS_PACKAGES_DIR/recenter_tc
+    pytest
 ```

--- a/docs/archive/CHANGELOG.md
+++ b/docs/archive/CHANGELOG.md
@@ -181,7 +181,7 @@ modified: tests/outputs/viirs.tc.Infrared-Gray.imagery_clean/20210209_074210_SH1
     * ssmis
     * viirs
 * **YAML outputs**
-    * Update from gdeck to bdeck parser
+    * Update from deck to bdeck parser
     * Update source\_filename to $GEOIPS bdeck file
     * Update source\_sector\_file to $GEOIPS bdeck file
     * Subset of data types impacted

--- a/docs/source/releases/1.15.1/1.15.1-bug-fixes.yaml
+++ b/docs/source/releases/1.15.1/1.15.1-bug-fixes.yaml
@@ -6,7 +6,7 @@ bug fix:
     modified:
     - 'pyproject.toml'
   related-issue:
-    internal: GEOIPS#753
+    internal: geoips#753
   date:
     start: 2025-04-08
     finish: 2025-04-08

--- a/docs/source/releases/1.16.0/1.16.0-internal-release.yaml
+++ b/docs/source/releases/1.16.0/1.16.0-internal-release.yaml
@@ -6,7 +6,7 @@ Release Process:
     added:
     - docs/source/releases/1.16.0/1.16.0-internal-release.yaml
   related-issue:
-    internal: GEOIPS#861 - 1.16.0 updates*
+    internal: geoips#861 - 1.16.0 updates*
   date:
     start: 2025-05-30
     finish: 2025-05-30

--- a/docs/source/releases/1.16.0/add-validation-pytest-marker.yaml
+++ b/docs/source/releases/1.16.0/add-validation-pytest-marker.yaml
@@ -1,0 +1,25 @@
+testing:
+- title: 'Import validation and lint test lists from geoips repo, and add validation pytest markers'
+  description: |
+    Rather than only having interfaces and plugin validation in the main geoips repo
+    (spanning all packages), include these tests in every repos integration tests,
+    to ensure they are regularly called.  Mark them with validation marker.
+
+    Import both the lint and validation test lists from the geoips repo test_integration.py,
+    since these tests are consistent for every plugin repo.
+
+    Also, mark sections in the integration test script for copy as-is, and update
+    per repo.
+  files:
+    deleted:
+    - ''
+    moved:
+    - ''
+    added:
+    - ''
+    modified:
+    - 'pytest.ini'
+    - 'tests/integration_tests/test_reponame.py'
+  date:
+    start: 2026-02-26
+    finish: 2026-02-26

--- a/docs/source/releases/1.16.0/pytest-add-lint-limited-dataset-markers.yaml
+++ b/docs/source/releases/1.16.0/pytest-add-lint-limited-dataset-markers.yaml
@@ -1,0 +1,18 @@
+testing:
+  - title: "Update to standard pytest based integration test setup"
+    description: |
+      * Update pytest.ini for new lint and limited dataset availability marker
+      * Separate base/lint/full tests in integration test script.
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - ""
+      modified:
+        - "pytest.ini"
+        - "tests/integration_tests/test_reponame.py"
+    date:
+      start: 2026-01-13
+      finish: 2026-01-23

--- a/docs/source/releases/1.16.1/1.16.1-site-test-bug-fixes.yaml
+++ b/docs/source/releases/1.16.1/1.16.1-site-test-bug-fixes.yaml
@@ -12,4 +12,4 @@ release updates:
     start: 2025-06-04
     finish: 2025-06-09
   related-issue:
-      internal: GEOIPS#861
+      internal: geoips#861 - 1.16.1 bug fixes

--- a/docs/source/releases/1.16.3/913-integrate-cimsstc-updates-1.yaml
+++ b/docs/source/releases/1.16.3/913-integrate-cimsstc-updates-1.yaml
@@ -14,6 +14,8 @@ enhancement:
     - ''
     modified:
     - 'recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py'
+  related-issue:
+    internal: geoips#913
   date:
     start: 2025-07-21
     finish: 2025-07-21

--- a/docs/source/releases/1.17.2/1.17.2-bug-use-storm-id-in-archer-filenames.yaml
+++ b/docs/source/releases/1.17.2/1.17.2-bug-use-storm-id-in-archer-filenames.yaml
@@ -1,0 +1,15 @@
+bug fix:
+- title: Use storm_id in archer_fix and archer_image filename formatters rather than area_id.
+  description: |
+    To avoid including the synoptic time in the archer filename outputs, use the
+    sector_info storm_id rather than the area_def area_id.
+  files:
+    modified:
+    - "recenter_tc/plugins/modules/filename_formatters/archer_fix.py"
+    - "recenter_tc/plugins/modules/filename_formatters/archer_image.py"
+  date:
+    start: 2025-11-19
+    finish: 2025-11-19
+  related-issue:
+    internal: geoips#959 - 1.17.2 updates
+

--- a/docs/source/releases/1.17.3/1.17.3-release-note.yaml
+++ b/docs/source/releases/1.17.3/1.17.3-release-note.yaml
@@ -1,5 +1,5 @@
 documentation:
-- title: Add release note for version 1.15.2
+- title: Add release note for version 1.17.3
   description: |
     Release note on release branch to force tag/release, package/publish,
     and deploy docs.
@@ -7,11 +7,11 @@ documentation:
     Additionally add any updated files from geoips_ci/sync
   files:
     added:
-    - docs/source/releases/latest/1.15.2-release-note.yaml
+    - docs/source/releases/latest/1.17.3-release-note.yaml
     modified:
     - geoips_ci/sync updated files
   date:
-    start: 2025-05-13
-    finish: 2025-05-13
+    start: 2026-02-10
+    finish: 2026-02-10
   related-issue:
-    internal: geoips#753 - 1.15.2 updates
+    internal: geoips#1029 - 1.17.3 updates

--- a/docs/source/releases/1.17.3/fix-storm-ids.yaml
+++ b/docs/source/releases/1.17.3/fix-storm-ids.yaml
@@ -1,0 +1,49 @@
+refactor:
+  - title: "Remove hard coded tc_year, tc_basin, tc_stormnum, and output_dict from tc_storm_basedir calls"
+    description: |
+      * Use information in the sector_info dictionary to populate the tc_storm_basedir.
+      * No longer explicitly pass tc_year/basin/stormnum.
+      * Note output_dict was previously used within tc_file_naming get_storm_subdir to
+        ONLY get the file_path_modifiations (existing_invest_dirs_allowable_time_diff,
+        and unique_invest_dirs). These are no longer supported
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - ""
+      modified:
+        - "recenter_tc/plugins/modules/filename_formatters/archer_fix.py"
+        - "recenter_tc/plugins/modules/filename_formatters/archer_image.py"
+    date:
+      start: 2026-01-05
+      finish: 2026-01-08
+  - title: "Produce one metadata_tc output, and add archer fix and image fnames to archer_info output"
+    description: |
+      * Update to use metadata_tc vs metadata_default (all other tests use metadata_default in recenter_tc)
+      * Add include_archer_info true to recenter_tc_kwargs in amsr2 test script
+      * Add archer_fix_fname and archer_image_fname to archer_info in recenter_tc
+      * Update amsr2 YAML output to include all sector_info fields, archer_info field,
+        including the new archer_fix_fname and archer_image_fname entries.
+      * This tests the archer fname outputs and the full archer output for at least one
+        data type - previously these were not tested at all. The ARCHER fix line is
+        tested in all recenter_tc metadata_default outputs (since archer_fdeck is
+        included in metadata_default), but the filenames, full output, etc is now only
+        tested for amsr2.
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - ""
+      modified:
+        - "recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py"
+        - "tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml"
+        - "tests/scripts/amsr2.tc.color37.imagery_clean.sh"
+        - "recenter_tc/plugins/modules/filename_formatters/archer_fix.py"
+        - "recenter_tc/plugins/modules/filename_formatters/archer_image.py"
+    date:
+      start: 2026-01-12
+      finish: 2026-01-12

--- a/docs/source/releases/1.17.3/pytest-add-lint-marker.yaml
+++ b/docs/source/releases/1.17.3/pytest-add-lint-marker.yaml
@@ -1,0 +1,18 @@
+testing:
+  - title: "Update to standard pytest based integration test setup"
+    description: |
+      * Update pytest.ini for new lint marker
+      * Separate base/lint/full tests in integration test script.
+    files:
+      deleted:
+        - ""
+      moved:
+        - ""
+      added:
+        - ""
+      modified:
+        - "pytest.ini"
+        - "tests/integration_tests/test_reponame.py"
+    date:
+      start: 2026-01-13
+      finish: 2026-01-13

--- a/docs/source/releases/1.18.0/1.18.0-internal-release.yaml
+++ b/docs/source/releases/1.18.0/1.18.0-internal-release.yaml
@@ -1,0 +1,12 @@
+Release Process:
+- title: Add 1.18.0 release note
+  description: |
+    Currently tagged internal version 1.17.3.
+  files:
+    added:
+    - docs/source/releases/1.18.0/1.18.0-internal-release.yaml
+  related-issue:
+    internal: geoips#1029 - 1.18.0 updates*
+  date:
+    start: 2026-03-07
+    finish: 2026-03-07

--- a/docs/source/releases/1.18.0/1.18.0-patch-internal-standard-sync-updates.yaml
+++ b/docs/source/releases/1.18.0/1.18.0-patch-internal-standard-sync-updates.yaml
@@ -1,0 +1,17 @@
+bug fixes:
+- title: Standard sync updates.
+  description: |
+    * Integration test script formatting
+    * add tests/conftest.py
+    * Other standard sync file updates
+    * black updates
+  files:
+    added:
+    - tests/conftest.py
+    modified:
+    - tests/integration_tests/test_package.py
+  related-issue:
+    internal: geoips#1029 - 1.18.0 updates
+  date:
+    start: 2026-03-10
+    finish: 2026-03-10

--- a/docs/source/releases/1.18.0/1.18.0-release-note.yaml
+++ b/docs/source/releases/1.18.0/1.18.0-release-note.yaml
@@ -1,5 +1,5 @@
 documentation:
-- title: Add release note for version 1.15.2
+- title: Add release note for version 1.18.0
   description: |
     Release note on release branch to force tag/release, package/publish,
     and deploy docs.
@@ -7,11 +7,11 @@ documentation:
     Additionally add any updated files from geoips_ci/sync
   files:
     added:
-    - docs/source/releases/latest/1.15.2-release-note.yaml
+    - docs/source/releases/latest/1.18.0-release-note.yaml
     modified:
     - geoips_ci/sync updated files
   date:
-    start: 2025-05-13
-    finish: 2025-05-13
+    start: 2026-03-17
+    finish: 2026-03-17
   related-issue:
-    internal: geoips#753 - 1.15.2 updates
+    internal: geoips#1029 - 1.18.0 updates

--- a/docs/source/releases/1.18.1/1.18.1-open-source-upload.yaml
+++ b/docs/source/releases/1.18.1/1.18.1-open-source-upload.yaml
@@ -1,0 +1,7 @@
+Release Updates - Open Source Upload:
+- title: Open source upload
+  description: "This repo updated with current geoips version release"
+  files:
+    modified:
+    - standard sync files
+    - release notes

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 [pytest]
 # Currently importlib required for CLI, but breaks pytest-based integration tests
 # addopts = -v -rf --ff --cov-report=term-missing -m "not integration" --import-mode=importlib
-addopts = -v -rf --ff --cov-report=term-missing -m "not optional"
+addopts = -v -rf --ff --cov-report=term-missing -m "not optional and not disabled and not limited_test_dataset_availability"
 pythonpath = .
 # Include */tests as well as tests, so this pytest.ini can be used from either the
 # top level GEOIPS_PACKAGES_DIR, or within an individual repository, with the same
@@ -15,45 +15,11 @@ norecursedirs =
     xarray_utils
     templates/tests
 markers =
-    # 'system, 'scheduler', 'integration', 'spans_multiple_packages',
-    # 'optional', 'disabled', 'sample_output', and 'tiny_sector'
-    # markers can be applied concurrently with any other marker.
-
-    # The following markers should be disjoint - there should be NO common tests between
-    # them.
-    # Individual repo markers:
-    #    base, lint, full
-    # GeoIPS System Implementation markers:
-    #    system = realtime, external_preprocessing, driver, database, scrubber, downloader
-    # Scheduler markers:
-    #    scheduler = driver, database, scrubber, downloader
-
     ###################################################################################
     ###################################################################################
-    # Optional and tiny_sector or sample_output typically marked concurrently.
-    # This provides an exhaustive test of all tiny sectors and example imagery tests.
-
-    optional: OPTIONAL INDEPENDENT - marks tests as optional (select with '-m "optional"', exclude with '-m "not optional"')
-    disabled: OPTIONAL INDEPENDENT - marks tests as disabled (select with '-m "disabled"', exclude with '-m "not disabled"')
-    sample_output: CONCURRENT - marks optional integration tests as producing example imagery outputs (no image output comparisons)
-    tiny_sector: CONCURRENT - marks optional integration tests as specifically testing ALL tiny_sectors (select with '-m "tiny_sector"')
-    tiny_sector_evaluation: CONCURRENT - marks optional integration tests as specifically running tests intended to evaluate and develop tiny_sectors (select with '-m "tiny_sector_evaluation"')
-    tiny_sector_global_example: CONCURRENT - marks optional integration tests as specifically producing global example imagery to aid in evaluating and developing tiny sectors for a given dataset (select with '-m "tiny_sector_global_example"')
-    tiny_sector_overlay: CONCURRENT - marks optional integration tests as specifically producing geoips overlay examples for evaluating and developing tiny sectors (select with '-m "tiny_sector_overlay"')
-
+    # Required Independent Markers
     ###################################################################################
-    ###################################################################################
-    # integration and spans_multiple_packages
-    # can be applied concurrently with other markers.
-
-    scheduler: CONCURRENT - marks tests as part of a suite of schedulers, for use in realtime processing (select with '-m "scheduler"')
-    system: CONCURRENT - marks tests as part of a system-wide test (select with '-m "system"')
-    integration: CONCURRENT - marks tests as integration (select with '-m "integration"')
-    spans_multiple_packages: CONCURRENT - marks integration tests that test functionality that could fail due to errors in multiple repositories. e.g. listing or validating all plugins, etc. Allows calling tests to ensure the same error will not cause tests in multiple repos to fail.
-
-    ###################################################################################
-    ###################################################################################
-    # base+lint+full is a complete test of everything within the current repository
+    # base+lint+validation+full is a complete test of everything within the current repository
     # If any tests require functionality in another plugin repository (besides the
     # geoips repository), they should additionally be marked with
     # "spans_multiple_packages"
@@ -61,13 +27,46 @@ markers =
     # These markers should be disjoint - there should be
     # NO common tests between them. Always include a single base test for basic
     # functionality tests for the plugin repo, as well as build_docs/check_code within
-    # the 'lint' marker. All other repo tests are marked 'full'.
+    # the 'lint' marker, and interface and plugin validation within the 'validation'
+    # marker. All other repo tests are marked 'full'.
 
     base: REQUIRED INDEPENDENT - integration tests that complete very quickly and require only a minimal installation for testing basic functionality within the current repository
     lint: REQUIRED INDEPENDENT - integration tests performing linting on the current repository, this includes documentation and code formatting checks.
-    full: REQUIRED INDEPENDENT - integration tests that require a 'full' installation for testing all functionality within the current repository. 'full' marker includes all tests for the current repo except for tests included in the optional 'base' marker.
+    validation: REQUIRED INDEPENDENT - integration tests performing validation on the plugins in the current repository, this includes interface and plugin validation.
+    full: REQUIRED INDEPENDENT - integration tests that require a 'full' installation for testing all functionality within the current repository. 'full' marker includes all tests for the current repo except for tests included in the 'base' and 'lint' markers.
 
     ###################################################################################
+    ###################################################################################
+    # Optional Concurrent Limitation Markers
+    ###################################################################################
+    # integration, spans_multiple_packages, limited_test_dataset_availability,
+    # optional, and disabled
+    # can be applied concurrently with other markers.
+
+    integration: CONCURRENT - marks tests as integration (select with '-m "integration"')
+    optional: CONCURRENT - marks tests as optional (select with '-m "optional"', exclude with '-m "not optional"')
+    disabled: CONCURRENT - marks tests as disabled (select with '-m "disabled"', exclude with '-m "not disabled"')
+    spans_multiple_packages: CONCURRENT - marks integration tests that test functionality that could fail due to errors in multiple repositories. e.g. listing or validating all plugins, etc. Allows calling tests to ensure the same error will not cause tests in multiple repos to fail.
+    limited_test_dataset_availability: CONCURRENT - marks integration tests that may have limited test dataset availability so may not be available to all users.
+
+    ###################################################################################
+    ###################################################################################
+    # Optional Concurrent Test Sector Markers
+    ###################################################################################
+    # Markers specifically for developing, evaluating, and testing sectors.
+    # This provides an exhaustive test of sectors and example imagery outputs.
+    # Typically applied concurrently with optional, since these tests do not need to
+    # be run regularly, but only during development and testing of new sectors.
+
+    sector_output_comparison: CONCURRENT - marks integration tests as producing output imagery with comparison references (select with '-m "sector_output_comparison"')
+    sample_output: CONCURRENT - marks optional integration tests as producing example imagery outputs (no image output comparisons)
+    sector_evaluation: CONCURRENT - marks optional integration tests as specifically running tests intended to evaluate and develop sectors (select with '-m "sector_evaluation"')
+    sector_global_example: CONCURRENT - marks optional integration tests as specifically producing global example imagery to aid in evaluating and developing sectors for a given dataset (select with '-m "sector_global_example"')
+    sector_overlay: CONCURRENT - marks optional integration tests as specifically producing geoips overlay examples for evaluating and developing sectors (select with '-m "sector_overlay"')
+
+    ###################################################################################
+    ###################################################################################
+    # Optional Concurrent System Markers
     ###################################################################################
     # system=external_preprocessing+realtime+driver+scrubber+database+downloader
     # scheduler=driver+scrubber+database+downloader
@@ -78,6 +77,13 @@ markers =
     # Please see software requirements specification (SRS) for more information on the
     # "GeoIPS System" definition.
 
+    scheduler: CONCURRENT - marks tests as part of a suite of schedulers, for use in realtime processing (select with '-m "scheduler"')
+    system: CONCURRENT - marks tests as part of a system-wide test (select with '-m "system"')
+
+    ###################################################################################
+    ###################################################################################
+    # Optional Independent System Markers
+    ###################################################################################
     # These markers should be disjoint - there should be
     # NO common tests between them.
 

--- a/recenter_tc/plugins/modules/filename_formatters/archer_fix.py
+++ b/recenter_tc/plugins/modules/filename_formatters/archer_fix.py
@@ -86,10 +86,6 @@ def call(
         basedir=basedir,
         variable_name=variable_name,
         archer_channel_type=archer_channel_type,
-        tc_area_id=area_def.area_id,
-        tc_year=int(area_def.sector_info["storm_year"]),
-        tc_basin=area_def.sector_info["storm_basin"],
-        tc_stormnum=int(area_def.sector_info["storm_num"]),
         source_name=xarray_obj.source_name,
         platform_name=xarray_obj.platform_name,
         product_datetime=xarray_obj.start_datetime,
@@ -97,6 +93,7 @@ def call(
         basin_letter=basin_letter,
         extension=extension,
         use_storm_subdirs=use_storm_subdirs,
+        sector_info=area_def.sector_info,
     )
 
 
@@ -104,15 +101,12 @@ def assemble_archer_fname(
     basedir,
     variable_name,
     archer_channel_type,
-    tc_area_id,
-    tc_year,
-    tc_basin,
-    tc_stormnum,
     source_name,
     platform_name,
     product_datetime,
     data_provider,
     basin_letter,
+    sector_info,
     extension=".txt",
     use_storm_subdirs=False,
 ):
@@ -122,20 +116,18 @@ def assemble_archer_fname(
     ----------
     basedir: string
         base directory
-    tc_year: int
-        Full 4 digit storm year
-    tc_basin: str
-        2 character basin designation
-        SH Southern Hemisphere
-        WP West Pacific
-        EP East Pacific
-        CP Central Pacific
-        IO Indian Ocean
-        AL Atlantic
-    tc_stormnum: integer
-        2 digit storm number
-        90 through 99 for invests
-        01 through 69 for named storms
+    sector_info: dict
+        Dictionary of TC sector info, including storm_year, storm_basin, storm_id, etc.
+    variable_name: string
+        Name of variable (e.g., 'B09BT')
+    archer_channel_type: string
+        Type of archer channel (e.g., 'Vis', 'IR', etc)
+    source_name: string
+        Name of data source (e.g., 'amsr2', 'smap', etc)
+    data_provider: string
+        Name of data provider (e.g., 'remss', 'ospo', etc)
+    basin_letter: string
+        Single letter basin designation (e.g., 'W', 'E', 'S', etc)
     platform_name: string
         Name of platform (satellite)
     product_datetime: datetime
@@ -160,23 +152,21 @@ def assemble_archer_fname(
     )
 
     if use_storm_subdirs:
-        path = pathjoin(
-            tc_storm_basedir(basedir, tc_year, tc_basin, tc_stormnum), "txt", "archer"
-        )
+        path = pathjoin(tc_storm_basedir(basedir, sector_info), "txt", "archer")
     else:
         path = basedir
     # MUST end in _02W_FIX (for example)
     fname = "_".join(
         [
             product_datetime.strftime("%Y%m%d.%H%M"),
-            tc_area_id,
+            sector_info["storm_id"].upper(),
             "archer",
             source_name,
             variable_name,
             archer_channel_type,
             data_provider,
             platform_name,
-            "{0:02d}{1}".format(tc_stormnum, basin_letter),
+            "{0:02d}{1}".format(sector_info["storm_num"], basin_letter),
             "FIX",
         ]
     )

--- a/recenter_tc/plugins/modules/filename_formatters/archer_image.py
+++ b/recenter_tc/plugins/modules/filename_formatters/archer_image.py
@@ -28,14 +28,11 @@ def call(
         basedir=basedir,
         variable_name=variable_name,
         archer_channel_type=archer_channel_type,
-        tc_area_id=area_def.area_id,
-        tc_year=int(area_def.sector_info["storm_year"]),
-        tc_basin=area_def.sector_info["storm_basin"],
-        tc_stormnum=int(area_def.sector_info["storm_num"]),
         source_name=xarray_obj.source_name,
         platform_name=xarray_obj.platform_name,
         product_datetime=xarray_obj.start_datetime,
         data_provider=xarray_obj.data_provider,
+        sector_info=area_def.sector_info,
         extension=extension,
     )
 
@@ -44,14 +41,11 @@ def assemble_archer_fname(
     basedir,
     variable_name,
     archer_channel_type,
-    tc_area_id,
-    tc_year,
-    tc_basin,
-    tc_stormnum,
     source_name,
     platform_name,
     product_datetime,
     data_provider,
+    sector_info,
     extension=".png",
 ):
     """Produce full output product path from product / sensor specifications.
@@ -60,24 +54,22 @@ def assemble_archer_fname(
     ----------
     basedir: string
         base directory
-    tc_year: int
-        Full 4 digit storm year
-    tc_basin: string
-        2 character basin designation
-        SH Southern Hemisphere
-        WP West Pacific
-        EP East Pacific
-        CP Central Pacific
-        IO Indian Ocean
-        AL Atlantic
-    tc_stormnum: int
-        2 digit storm number
-        90 through 99 for invests
-        01 through 69 for named storms
     platform_name: string
         Name of platform (satellite)
     product_datetime: datetime
         Start time of data used to generate product
+    sector_info: dict
+        Dictionary of TC sector info, including storm_year, storm_basin, storm_id, etc.
+    data_provider: string
+        Name of data provider (e.g., 'remss', 'ospo', etc)
+    source_name: string
+        Name of data source (e.g., 'amsr2', 'smap', etc)
+    variable_name: string
+        Name of variable (e.g., 'B09BT')
+    archer_channel_type: string
+        Type of archer channel (e.g., 'pmw', 'ir', 'vis')
+    extension: string
+        File extension (including leading period), default '.png'
 
     Returns
     -------
@@ -97,13 +89,16 @@ def assemble_archer_fname(
         tc_storm_basedir,
     )
 
-    path = pathjoin(
-        tc_storm_basedir(basedir, tc_year, tc_basin, tc_stormnum), "png", "archer"
-    )
+    # Use the standard tc storm basedir, as defined in geoips repo.
+    path = pathjoin(tc_storm_basedir(basedir, sector_info), "png", "archer")
+    # Upper case for storm_id in filenames, lower case internally.
+    # Note since we are using storm_id explicitly, this will include
+    # storm start datetime for invests and will NOT include storm
+    # start datetime for numbered storms.
     fname = "_".join(
         [
             product_datetime.strftime("%Y%m%d.%H%M"),
-            tc_area_id,
+            sector_info["storm_id"].upper(),
             "archer",
             source_name,
             variable_name,

--- a/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
+++ b/recenter_tc/plugins/modules/sector_adjusters/recenter_tc.py
@@ -10,6 +10,7 @@ import logging
 import pyresample
 
 from geoips.filenames.base_paths import make_dirs
+from geoips.geoips_utils import replace_geoips_paths
 from geoips.interfaces import filename_formatters
 from geoips.errors import CoverageError
 from geoips.commandline.log_setup import log_with_emphasis
@@ -216,10 +217,12 @@ def run_archer(xarray_obj, varname):
     first_guess["lat"] = xarray_obj.area_definition.sector_info["clat"]
     first_guess["lon"] = xarray_obj.area_definition.sector_info["clon"]
 
+    archer_info = {}
     out_fnames = []
     if archer_image_fname is not None:
         make_dirs(dirname(archer_image_fname))
         out_fnames += [archer_image_fname]
+        archer_info["archer_image_fname"] = replace_geoips_paths(archer_image_fname)
         LOG.interactive("ARCHERSUCCESS Writing ARCHER image: %s", archer_image_fname)
     from archer.archer4 import archer4
 
@@ -235,11 +238,11 @@ def run_archer(xarray_obj, varname):
     if archer_fix_fname is not None:
         make_dirs(dirname(archer_fix_fname))
         out_fnames += [archer_fix_fname]
+        archer_info["archer_fix_fname"] = replace_geoips_paths(archer_fix_fname)
         with open(archer_fix_fname, "w") as fobj:
             fobj.write(out_dict["fdeck_string"])
         LOG.interactive("ARCHERSUCCESS Wrote ARCHER fdeck: %s", archer_fix_fname)
 
-    archer_info = {}
     for field in [
         "uses_target",
         "archer_channel_type",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# # # This source code is subject to the license referenced at
+# # # https://github.com/NRLMMD-GEOIPS.
+
 """Pytest configuration for test data validation.
 
 Provides command-line options and fixtures to control test behavior
@@ -20,12 +23,16 @@ def pytest_addoption(parser):
     Adds --no-fail-on-missing-data flag to skip tests instead of
     failing when test data is unavailable.
     """
-    parser.addoption(
-        "--no-fail-on-missing-data",
-        action="store_true",
-        default=False,
-        help="Fail tests if test data is missing",
-    )
+    try:
+        parser.addoption(
+            "--no-fail-on-missing-data",
+            action="store_true",
+            default=False,
+            help="Fail tests if test data is missing",
+        )
+    except ValueError as resp:
+        if "option names {'--no-fail-on-missing-data'} already added" in str(resp):
+            pass
 
 
 @pytest.fixture

--- a/tests/integration_tests/test_recenter_tc.py
+++ b/tests/integration_tests/test_recenter_tc.py
@@ -1,28 +1,51 @@
 # # # This source code is subject to the license referenced at
 # # # https://github.com/NRLMMD-GEOIPS.
 
+#######################################################################################
+#######################################################################################
+# Start basic pytest imports
+# These can be copied as is between repositories and provide the basic pytest-based
+# integration test functionality required by all repositories.
+#######################################################################################
+
 """Pytest file for calling integration bash scripts."""
 
 import os
 import pytest
 
-# Only use base_setup, because full_setup requires ALL test data repositories.
+# Only use base_setup, because full setup requires ALL test data repositories.
 from tests.integration_tests.test_integration import base_setup  # noqa: F401
+
+# Import the validation and lint test calls, these are identical for all repos
+from tests.integration_tests.test_integration import (
+    validation_integ_test_calls,
+    lint_integ_test_calls,
+)
 
 from tests.integration_tests.test_integration import (
     run_script_with_bash,
     setup_environment as setup_geoips_environment,
 )
 
-# Single base test to ensure plugin repo works at all.
+#######################################################################################
+# End basic pytest imports
+# Copied as is between repos
+#######################################################################################
+#######################################################################################
+
+#######################################################################################
+#######################################################################################
+# Start repo specific pytest functionality
+# These cannot be copied as is between repositories
+#######################################################################################
+
+# Single base test to ensure basic plugin repo functionality.
 base_integ_test_calls = [
     "$repopath/tests/scripts/gmi.tc.89pct.imagery_clean.sh",
 ]
 
 # Exhaustive test of all remaining functionality in this repo (excluding base test).
 full_integ_test_calls = [
-    "$geoips_repopath/tests/utils/check_code.sh all $repopath",
-    "$geoips_repopath/docs/build_docs.sh $repopath $pkgname html_only",
     "$repopath/tests/scripts/abi.tc.Visible.imagery_clean.sh",
     "$repopath/tests/scripts/ahi.tc.IR-BD.imagery_clean.sh",
     "$repopath/tests/scripts/amsr2.tc.color37.imagery_clean.sh",
@@ -40,6 +63,7 @@ full_integ_test_calls = [
     "$repopath/tests/scripts/smos.tc.windspeed.imagery_clean.sh",
     "$repopath/tests/scripts/viirs.tc.Infrared-Gray.imagery_clean.sh",
 ]
+
 # Test scripts that require test datasets with limited availability.
 limited_data_integ_test_calls = [
     "$repopath/tests/scripts/amsub_hdf.tc.157V.imagery_clean.sh",
@@ -68,8 +92,50 @@ def setup_environment():
     # Setup base geoips environment
     setup_geoips_environment()
     # Setup current repo's environment
-    os.environ["repopath"] = os.path.join(os.path.dirname(__file__), "..", "..")
+    os.environ["repopath"] = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), "..", "..")
+    )
     os.environ["pkgname"] = "recenter_tc"
+
+
+# These are required to test the full functionality of this repo, but have limited
+# test dataset availability, so mark them as limited_test_dataset_availability.
+@pytest.mark.limited_test_dataset_availability
+@pytest.mark.integration
+@pytest.mark.parametrize("script", limited_data_integ_test_calls)
+def test_integ_limited_data_script(
+    base_setup: None, script: str, fail_on_missing_data: bool  # noqa: F811
+):
+    """
+    Run integration test scripts by executing specified shell commands.
+
+    Parameters
+    ----------
+    script : str
+        Shell command to execute as part of the integration test. The command may
+        contain environment variables which will be expanded before execution.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the shell command returns a non-zero exit status.
+    """
+    setup_environment()
+    run_script_with_bash(script, fail_on_missing_data)
+
+
+#######################################################################################
+# End repo specific pytest functionality
+# Not copied as is between repos
+#######################################################################################
+#######################################################################################
+
+#######################################################################################
+#######################################################################################
+# Start basic pytest functions
+# These can be copied as is between repositories and provide the basic pytest-based
+# integration test functionality required by all repositories.
+#######################################################################################
 
 
 @pytest.mark.base
@@ -120,14 +186,10 @@ def test_integ_full_test_script(
     run_script_with_bash(script, fail_on_missing_data)
 
 
-# These are required to test the full functionality of this repo, but have limited
-# test dataset availability, so mark them as optional.
-@pytest.mark.optional
+@pytest.mark.lint
 @pytest.mark.integration
-@pytest.mark.parametrize("script", limited_data_integ_test_calls)
-def test_integ_limited_data_script(
-    base_setup: None, script: str, fail_on_missing_data: bool  # noqa: F811
-):
+@pytest.mark.parametrize("script", lint_integ_test_calls)
+def test_integ_lint_test_script(base_setup: None, script: str):  # noqa: F811
     """
     Run integration test scripts by executing specified shell commands.
 
@@ -143,4 +205,33 @@ def test_integ_limited_data_script(
         If the shell command returns a non-zero exit status.
     """
     setup_environment()
-    run_script_with_bash(script, fail_on_missing_data)
+    run_script_with_bash(script)
+
+
+@pytest.mark.validation
+@pytest.mark.integration
+@pytest.mark.parametrize("script", validation_integ_test_calls)
+def test_integ_validation_script(base_setup: None, script: str):  # noqa: F811
+    """
+    Run integration test scripts by executing specified shell commands.
+
+    Parameters
+    ----------
+    script : str
+        Shell command to execute as part of the integration test. The command may
+        contain environment variables which will be expanded before execution.
+
+    Raises
+    ------
+    subprocess.CalledProcessError
+        If the shell command returns a non-zero exit status.
+    """
+    setup_environment()
+    run_script_with_bash(script)
+
+
+#######################################################################################
+# End basic pytest functions
+# Copied as is between repos
+#######################################################################################
+#######################################################################################

--- a/tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml
+++ b/tests/outputs/amsr2.tc.color37.imagery_clean/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png.yaml
@@ -3,6 +3,27 @@ aid_type: BEST
 archer_fdeck: IO, 1, 2005180736,  70, AMS2,          C,  , 1353N,  8620E,      , 1,    ,  ,     ,  ,     ,    ,     ,     ,     ,     ,     ,  ,  ,  ,  ,  ,    ,    ,  ,  CIMS,
   AUT,    ,             ,             ,    ,     ,                        x, irad=0.40
   | r50=0.11 | r95=0.31 | ep=-99 | src=ARCH
+archer_info:
+  alpha_parameter: 15.325279511465972
+  archer_channel_type: 37GHz
+  archer_fix_fname: $GEOIPS_OUTDIRS/preprocessed/archer/fix/20200518.0736_IO012020_archer_amsr2_tb36h_37GHz_star_gcom-w1_01B_FIX
+  archer_image_fname: $GEOIPS_OUTDIRS/preprocessed/archer/image/tc2020/IO/IO012020/png/archer/20200518.0736_IO012020_archer_amsr2_tb36h_37GHz_star_gcom-w1.png
+  center_lat: 13.530000000000001
+  center_lon: 86.19999999999999
+  confidence_score: 3.5684965909726536
+  eye_prob: null
+  fdeck_string: IO, 1, 2005180736,  70, AMS2,          C,  , 1353N,  8620E,      ,
+    1,    ,  ,     ,  ,     ,    ,     ,     ,     ,     ,     ,  ,  ,  ,  ,  ,    ,    ,  ,  CIMS,
+    AUT,    ,             ,             ,    ,     ,                        x, irad=0.40
+    | r50=0.11 | r95=0.31 | ep=-99 | src=ARCH
+  radius50percCertDeg: 0.11
+  radius95percCertDeg: 0.31
+  ring_radius_deg: 0.4
+  uses_target: true
+  weak_center_lat: null
+  weak_center_lon: null
+area_description: io012020-2020051806 AMPHAN interpolated_time 2020-05-18 07:38:42.500000
+area_id: io012020-2020051806
 bounding_box:
   image_height: 1400
   image_width: 1400
@@ -16,11 +37,27 @@ bounding_box:
     +units=m +x_0=0 +y_0=0
 clat: 13.53
 clon: 86.2
+covg_info:
+  fname_covg: 99.86321428571429
+  fname_covg_args: {}
+  fname_covg_func: rgba
+  full_covg: 99.86321428571429
+  full_covg_args: {}
+  full_covg_func: rgba
+  image_production_covg: 99.86321428571429
+  image_production_covg_args: {}
+  image_production_covg_func: rgba
+data_provider: star
+data_times:
+  end: 2020-05-18 07:41:27
+  mid: 2020-05-18 07:38:45.500000
+  start: 2020-05-18 07:36:04
 deck_line: IO, 01, 2020051806,   , BEST,   0, 134N,  862E, 140,  911, ST,  34, NEQ,  155,  125,  160,  145,  999,  200,   5,   0,  10,   B,   0,    ,   0,   0,     AMPHAN,
   D,
 final_storm_name: AMPHAN
 interpolated_time: 2020-05-18 07:38:42.500000
 invest_number: 91
+invest_storm_id: io9120202020051506
 parser_name: bdeck_parser
 pressure: 908.28
 product_filename: $GEOIPS_OUTDIRS/preprocessed/tcwww/tc2020/IO/IO012020/png_clean/color37/gcom-w1/20200518_073604_IO012020_amsr2_gcom-w1_color37_142kts_99p86_res1p0-artb36h-clean.png
@@ -31,9 +68,12 @@ source_file_names:
 source_filename: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 source_sector_file: $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat
 storm_basin: IO
+storm_id: io012020
 storm_name: AMPHAN
 storm_num: 1
-storm_start_datetime: 2020-05-15 06:00:00
+storm_start_datetime: &id001 2020-05-15 06:00:00
+storm_start_datetime_from_filename_of_current_deck_file: null
+storm_start_datetime_from_first_line_of_current_deck_file: *id001
 storm_year: 2020
 synoptic_time: 2020-05-18 06:00:00
 vmax: 141.53

--- a/tests/scripts/amsr2.tc.color37.imagery_clean.sh
+++ b/tests/scripts/amsr2.tc.color37.imagery_clean.sh
@@ -12,10 +12,11 @@ geoips run single_source \
     --output_formatter imagery_clean \
     --filename_formatter tc_clean_fname \
     --metadata_filename_formatter metadata_default_fname \
-    --metadata_output_formatter metadata_default \
+    --metadata_output_formatter metadata_tc \
     --trackfile_parser bdeck_parser \
     --trackfiles $GEOIPS_PACKAGES_DIR/geoips/tests/sectors/tc_bdecks/bio012020.dat \
-    --sector_adjuster recenter_tc
+    --sector_adjuster recenter_tc \
+    --sector_adjuster_kwargs '{"include_archer_info": True}'
 ss_retval=$?
 
 exit $((ss_retval))


### PR DESCRIPTION
# Related Issues
required to close NRLMMD-GEOIPS/geoips#1246

# Reviewer Instructions
* Please confirm this PR is set up to merge from v1.18.1-version-release branch into main branch
* Review "Files changed" tab
* Confirm appropriate testing was completed for these updates (you may perform tests yourself, or review output included from another reviewer/assignee)

# Summary
Changes for version 1.18.0, uploaded with
1.18.1 update on repo recenter_tc.
See release note updates in 'Files changed' tab

See NRLMMD-GEOIPS/geoips#1246 for additional repositories included in this update.

# Testing Instructions
See NRLMMD-GEOIPS/geoips#1246 for testing instructions.

# Output
See NRLMMD-GEOIPS/geoips#1246 for test output.

# Pre Merge Steps
* geoips repo must be merged first during the release process so all other repos reference the correct geoips version.
* geoips_ci repo must be merged second so CI is up to date for all other repos.
* Once geoips and geoips_ci are merged, then the remaining version release PRs can be merged on all remaining repos.

# Post Merge Steps
Once this PR has been merged, 1.18.0
will be tagged/released on the recenter_tc main branch.